### PR TITLE
release: various small fixes to publish the provider to the registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,6 @@ jobs:
         with:
           go-version-file: go.mod
       - uses: ./.github/actions/build-provider
-      - name: Import gpg key
-        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload artifacts
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
@@ -59,6 +54,11 @@ jobs:
           path: dist
           name: release-artifacts
           merge-multiple: true
+      - name: Import gpg key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Create a Github release
         run: |
           gpg --list-signatures

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Create a Github release
+        env:
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
         run: |
           gpg --list-signatures
           go run ./tools/publish/cmd github create \

--- a/tools/publish/pkg/publish/artifacts.go
+++ b/tools/publish/pkg/publish/artifacts.go
@@ -137,7 +137,7 @@ func (a *Artifacts) SHA256Sum(path string) (string, error) {
 type RegistryManifest struct {
 	Version  json.Number `json:"version,omitempty"`
 	Metadata struct {
-		ProtocolVersions []json.Number `json:"protocol_versions,omitempty"`
+		ProtocolVersions []string `json:"protocol_versions,omitempty"`
 	} `json:"metadata,omitempty"`
 	// The rest of the fields we track internally but don't marshal to and from the base and versioned manifest
 	sha256sum     string

--- a/tools/publish/pkg/publish/artifacts_test.go
+++ b/tools/publish/pkg/publish/artifacts_test.go
@@ -5,7 +5,9 @@ package publish
 
 import (
 	"archive/zip"
+	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -48,4 +50,23 @@ func TestCreateZipArchiveFilePermissions(t *testing.T) {
 
 		assert.Equal(t, mode.String(), zip.File[0].FileHeader.Mode().String())
 	}
+}
+
+func TestReleaseManifestVersionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	var err error
+	artifacts := NewArtifacts("test")
+	artifacts.dir = dir
+	content := `{"version":1,"metadata":{"protocol_versions":["6.0"]}}`
+	path := filepath.Join(dir, "manifest.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), fs.FileMode(0o755)))
+	require.NoError(t, artifacts.AddReleaseManifest(context.Background(), path, "0.5.0"))
+	require.NoError(t, artifacts.CreateVersionedRegistryManifest(context.Background()))
+	f, err := os.Open(artifacts.registryManifest.versionedPath)
+	require.NoError(t, err)
+	got, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, content, string(got))
 }


### PR DESCRIPTION
We were importing the key on the wrong workflow. We don't actually sign the artifacts until right before we create a release.