### PR TITLE
release: create the correct SHA256SUMS file for the public registry

### DIFF
--- a/tools/publish/cmd/github.go
+++ b/tools/publish/cmd/github.go
@@ -116,7 +116,7 @@ func runGHReleaseCreateCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = stagedRelease.WriteSHA256Sums(ctx, githubReleaseCreateReq.GPGIdentityName, true)
+	err = stagedRelease.WriteSHA256Sums(ctx, publish.RegistryTypePublic, githubReleaseCreateReq.GPGIdentityName, true)
 	if err != nil {
 		return err
 	}

--- a/tools/publish/cmd/tfc_promote.go
+++ b/tools/publish/cmd/tfc_promote.go
@@ -83,7 +83,7 @@ func runTFCPromoteCmd(cmd *cobra.Command, args []string) {
 
 	exitIfErr(publishPromote.AddGoBinariesFrom(tfcPromoteCfg.PromoteDir))
 
-	exitIfErr(publishPromote.WriteSHA256Sums(ctx, tfcPromoteCfg.GPGIdentityName, true))
+	exitIfErr(publishPromote.WriteSHA256Sums(ctx, publish.RegistryTypePrivate, tfcPromoteCfg.GPGIdentityName, true))
 
 	uploadCfg := &publish.TFCUploadReq{
 		DistDir:         tfcPromoteCfg.PromoteDir,

--- a/tools/publish/cmd/tfc_upload.go
+++ b/tools/publish/cmd/tfc_upload.go
@@ -45,21 +45,21 @@ func runTFCUploadCmd(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), rootCfg.requestTimeout)
 	defer cancel()
 
-	publish := publish.NewLocal(tfcUploadCfg.ProviderName, tfcUploadCfg.BinaryName, publish.WithLocalBinaryRename(tfcUploadCfg.BinaryRename))
-	err := publish.Initialize()
+	mirror := publish.NewLocal(tfcUploadCfg.ProviderName, tfcUploadCfg.BinaryName, publish.WithLocalBinaryRename(tfcUploadCfg.BinaryRename))
+	err := mirror.Initialize()
 	exitIfErr(err)
-	defer publish.Close()
+	defer mirror.Close()
 
 	lvl, err := zapcore.ParseLevel(rootCfg.logLevel)
 	exitIfErr(err)
 
-	exitIfErr(publish.SetLogLevel(lvl))
+	exitIfErr(mirror.SetLogLevel(lvl))
 
-	exitIfErr(publish.AddGoBinariesFrom(tfcUploadCfg.DistDir))
+	exitIfErr(mirror.AddGoBinariesFrom(tfcUploadCfg.DistDir))
 
-	exitIfErr(publish.WriteSHA256Sums(ctx, tfcUploadCfg.GPGIdentityName, true))
+	exitIfErr(mirror.WriteSHA256Sums(ctx, publish.RegistryTypePrivate, tfcUploadCfg.GPGIdentityName, true))
 
-	exitIfErr(publish.PublishToTFC(ctx, tfcUploadCfg))
+	exitIfErr(mirror.PublishToTFC(ctx, tfcUploadCfg))
 
 	os.Exit(0)
 }

--- a/tools/publish/pkg/publish/local.go
+++ b/tools/publish/pkg/publish/local.go
@@ -159,11 +159,11 @@ func (l *Local) WriteMetadata() error {
 }
 
 // WriteSHA256Sums writes a detached signature of the source file to the outfile.
-func (l *Local) WriteSHA256Sums(ctx context.Context, name string, sign bool) error {
+func (l *Local) WriteSHA256Sums(ctx context.Context, regType RegistryType, name string, sign bool) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	return l.artifacts.WriteSHA256SUMS(ctx, name, sign)
+	return l.artifacts.WriteSHA256SUMS(ctx, regType, name, sign)
 }
 
 // PublishToTFC publishes artifact version to TFC org.


### PR DESCRIPTION
The SHA256SUMS filename is different if you're publishing to the private registry. Add support for creating the file and associated detached signature in the public registry mode.

We also ensure that we upload the SHA256SUMS and the signature file when creating a release.
