### PR TITLE
docs: fix some nested attributes being rendered incorrectly

### DIFF
--- a/docs/data-sources/artifactory_item.md
+++ b/docs/data-sources/artifactory_item.md
@@ -42,11 +42,11 @@ for every criteria. This means that you can use wildcards `*` for any field. See
 ### Read-Only
 
 - `id` (String) The datasource identifier is always static
-- `results` (List of Object) - ^results.name^ (String) The item name
-- ^results.type^ (String) The item type
-- ^results.url^ (String) The fully qualified URL to the item
-- ^results.sha256^ (String) The SHA256 sum of the item
-- ^results.size^ (String) The size of the item (see [below for nested schema](#nestedatt--results))
+- `results` (List of Object) - `results.name` (String) The item name
+- `results.type` (String) The item type
+- `results.url` (String) The fully qualified URL to the item
+- `results.sha256` (String) The SHA256 sum of the item
+- `results.size` (String) The size of the item (see [below for nested schema](#nestedatt--results))
 
 <a id="nestedatt--results"></a>
 ### Nested Schema for `results`

--- a/docs/resources/bundle_install.md
+++ b/docs/resources/bundle_install.md
@@ -28,18 +28,18 @@ only one can be configured at a time.
 
 ### Optional
 
-- `artifactory` (Object, Sensitive) - ^artifactory.username^ (String) The Artifactory API username. This will likely be your hashicorp email address
-- ^artifactory.token^ (String) The Artifactory API token. You can sign into Artifactory and generate one
-- ^artifactory.url^ (String) The fully qualified Artifactory item URL. You can use enos_artifactory_item to search for this URL
-- ^artifactory.sha256^ (String) The Artifactory item SHA 256 sum. If present this will be verified on the remote target before the package is installed (see [below for nested schema](#nestedatt--artifactory))
+- `artifactory` (Object, Sensitive) - `artifactory.username` (String) The Artifactory API username. This will likely be your hashicorp email address
+- `artifactory.token` (String) The Artifactory API token. You can sign into Artifactory and generate one
+- `artifactory.url` (String) The fully qualified Artifactory item URL. You can use enos_artifactory_item to search for this URL
+- `artifactory.sha256` (String) The Artifactory item SHA 256 sum. If present this will be verified on the remote target before the package is installed (see [below for nested schema](#nestedatt--artifactory))
 - `destination` (String) The destination directory of the installed binary, eg: /usr/local/bin/. This is required if the artifact is a zip archive and optional when installing RPM or Deb packages
 - `getter` (String) The method used to fetch the package
 - `installer` (String) The method used to install the package
 - `name` (String) The name of the artifact that was installed
 - `path` (String) The local path to a zip archive install bundle.
-- `release` (Object) - ^release.product^ (String) The product name that you wish to install, eg: 'vault' or 'consul'
-- ^release.version^ (String) The version of the product that you wish to install. Use the full semver version ('2.1.3' or 'latest')
-- ^release.edition^ (String) The edition of the product that you wish to install. Eg: 'ce', 'ent', 'ent.hsm', 'ent.hsm.fips', etc. (see [below for nested schema](#nestedatt--release))
+- `release` (Object) - `release.product` (String) The product name that you wish to install, eg: 'vault' or 'consul'
+- `release.version` (String) The version of the product that you wish to install. Use the full semver version ('2.1.3' or 'latest')
+- `release.edition` (String) The edition of the product that you wish to install. Eg: 'ce', 'ent', 'ent.hsm', 'ent.hsm.fips', etc. (see [below for nested schema](#nestedatt--release))
 - `transport` (Dynamic) - `transport.ssh` (Object) the ssh transport configuration
 - `transport.ssh.user` (String) the ssh login user|string
 - `transport.ssh.host` (String) the remote host to access

--- a/internal/plugin/datasource_artifactory_item.go
+++ b/internal/plugin/datasource_artifactory_item.go
@@ -218,13 +218,13 @@ for every criteria. This means that you can use wildcards ^*^ for any field. See
 					Type:            s.Results.TFType(),
 					Computed:        true,
 					DescriptionKind: tfprotov6.StringKindMarkdown,
-					Description: `
+					Description: docCaretToBacktick(`
 - ^results.name^ (String) The item name
 - ^results.type^ (String) The item type
 - ^results.url^ (String) The fully qualified URL to the item
 - ^results.sha256^ (String) The SHA256 sum of the item
 - ^results.size^ (String) The size of the item
-`,
+`),
 				},
 			},
 		},

--- a/internal/plugin/resource_bundle_install.go
+++ b/internal/plugin/resource_bundle_install.go
@@ -466,12 +466,12 @@ only one can be configured at a time.
 					Sensitive:       true, // mask the token
 					Optional:        true,
 					DescriptionKind: tfprotov6.StringKindMarkdown,
-					Description: `
+					Description: docCaretToBacktick(`
 - ^artifactory.username^ (String) The Artifactory API username. This will likely be your hashicorp email address
 - ^artifactory.token^ (String) The Artifactory API token. You can sign into Artifactory and generate one
 - ^artifactory.url^ (String) The fully qualified Artifactory item URL. You can use enos_artifactory_item to search for this URL
 - ^artifactory.sha256^ (String) The Artifactory item SHA 256 sum. If present this will be verified on the remote target before the package is installed
-`,
+`),
 				},
 				{
 					Name:     "release",
@@ -479,11 +479,11 @@ only one can be configured at a time.
 					Optional: true,
 
 					DescriptionKind: tfprotov6.StringKindMarkdown,
-					Description: `
+					Description: docCaretToBacktick(`
 - ^release.product^ (String) The product name that you wish to install, eg: 'vault' or 'consul'
 - ^release.version^ (String) The version of the product that you wish to install. Use the full semver version ('2.1.3' or 'latest')
 - ^release.edition^ (String) The edition of the product that you wish to install. Eg: 'ce', 'ent', 'ent.hsm', 'ent.hsm.fips', etc.
-`,
+`),
 				},
 				{
 					Name:        "getter",


### PR DESCRIPTION
### How to read this pull request
I noticed some weird rendering when looking at the docs on the registry. This fixes cases where we failed to render carets into back ticks for markdown. 0.5.6 hasn't been released yet so there's no need to bump the version.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
- [x] Version file/release label updated, if release needed
