### PR TITLE
`enos_artifactory_item`: Add support for passing a `query_template`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,112 +1,46 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
----
+version: "2"
 run:
-  timeout: 5m
   issues-exit-code: 1
   tests: true
-
-
-issues:
-  # make issues output unique by line, default is true
-  uniq-by-line: true
-
-# output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  # default is "colored-line-number"
   formats:
-    - format: colored-line-number
-  # print lines of code with issue, default is true
-  print-issued-lines: true
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-  # add a prefix to the output file references; default is no prefix
-  # path-prefix: ""
-  # sorts results by: filepath, line and column
-  sort-results: false
-
-# all available settings of specific linters
-linters-settings:
-  errcheck:
-    check-type-assertions: false
-    check-blank: false
-
-  cyclop:
-    max-complexity: 30
-    package-average: 0.0
-    skip-tests: false
-
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/hashicorp-forge
-
-  gofumpt:
-    extra-rules: false
-
-  gosec:
-    excludes:
-      # Don't worry about decompression bombs, not relevant for our usage of zip
-      - G110
-      # Don't worry about zip file traversals
-      - G305
-      # Don't worry about casting int -> uint
-      - G115
-    config:
-      G306:
-        # allow creating files with 0755 permissions
-        "0755"
-
-  interfacebloat:
-    max: 12
-
-  nlreturn:
-    # Size of the block (including return statement that is still "OK")
-    block-size: 2
-
-  revive:
-    # see https://github.com/mgechev/revive#available-rules for details.
-    ignore-generated-header: true
-    severity: warning
-
+    text:
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: true
 linters:
-  enable-all: true
+  default: all
   disable:
     - containedctx
     - depguard
     - dogsled
     - dupl
+    - err113
     - errname
     - errorlint
     - exhaustruct
     - fatcontext
     - forbidigo
     - forcetypeassert
+    - funcorder
     - funlen
-    - gci
     - ginkgolinter
     - gochecknoglobals
     - gochecknoinits
     - gocognit
     - goconst
-    # disabled for now
     - gocritic
     - gocyclo
-    # disabled for now
     - godox
-    - err113
-    - gofmt
     - goheader
-    - gomoddirectives # until we remove our go-cty fork
+    - gomoddirectives
     - importas
     - ireturn
     - lll
     - loggercheck
     - maintidx
-    - musttag
     - mnd
+    - musttag
     - nakedret
     - nestif
     - nonamedreturns
@@ -118,13 +52,58 @@ linters:
     - tagliatelle
     - testableexamples
     - testpackage
-    # disabled because it's not friendly with the terraform test helper
     - tparallel
     - varnamelen
     - wrapcheck
     - wsl
-  fast: false
-
+  settings:
+    cyclop:
+      max-complexity: 30
+      package-average: 0
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+    gosec:
+      excludes:
+        - G110
+        - G305
+        - G115
+      config:
+        G306: "0755"
+    interfacebloat:
+      max: 12
+    nlreturn:
+      block-size: 2
+    revive:
+      severity: warning
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  uniq-by-line: true
 severity:
-  default-severity: error
-  case-sensitive: false
+  default: error
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: false
+    goimports:
+      local-prefixes:
+        - github.com/hashicorp-forge
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ FLIGHTCONTROL_BUILD_TAGS?=-tags osusergo,netgo
 FLIGHTCONTROL_LD_FLAGS?=-ldflags="-extldflags=-static -s -w"
 
 CI?=false
-LINT_OUT_FORMAT?=colored-line-number
 .PHONY: HASUPX
 HASUPX:= $(shell upx dot 2> /dev/null)
 BUILD_DARWIN_FC?=false
@@ -131,11 +130,11 @@ fmt-check-enos:
 
 .PHONY: lint
 lint:
-	golangci-lint run -v --out-format=$(LINT_OUT_FORMAT)
+	golangci-lint run -v
 
 .PHONY: lint-fix
 lint-fix:
-	golangci-lint run -v --out-format=$(LINT_OUT_FORMAT) --fix
+	golangci-lint run -v --fix
 
 .PHONY: clean
 clean:

--- a/internal/artifactory/aql_test.go
+++ b/internal/artifactory/aql_test.go
@@ -23,7 +23,7 @@ func EnsureArtifactoryEnvAuth(t *testing.T) (map[string]string, bool) {
 	vars["username"], _ = os.LookupEnv("ARTIFACTORY_USER")
 	vars["token"], oktoken = os.LookupEnv("ARTIFACTORY_TOKEN")
 
-	if !(okacc && oktoken) {
+	if !okacc || !oktoken {
 		t.Logf(`skipping data "enos_artifactory_item" test because TF_ACC(%t), ARTIFACTORY_TOKEN(%t) aren't set`,
 			okacc, oktoken,
 		)
@@ -47,7 +47,7 @@ func EnsureArtifactoryEnvVars(t *testing.T) (map[string]string, bool) {
 	vars["version"], okver = os.LookupEnv("ARTIFACTORY_PRODUCT_VERSION")
 	vars["revision"], okrev = os.LookupEnv("ARTIFACTORY_REVISION")
 
-	if !(okacc && oktoken && okver && okrev) {
+	if !okacc || !oktoken || !okver || !okrev {
 		t.Logf(`skipping data "enos_artifactory_item" test because TF_ACC(%t), ARTIFACTORY_TOKEN(%t), ARTIFACTORY_PRODUCT_VERSION(%t), ARTIFACTORY_REVISION(%t) aren't set`,
 			okacc, oktoken, okver, okrev,
 		)

--- a/internal/flightcontrol/flightcontrol_test.go
+++ b/internal/flightcontrol/flightcontrol_test.go
@@ -89,7 +89,7 @@ func TestSupportedTargets(t *testing.T) {
 	t.Parallel()
 	targets, err := SupportedTargets()
 	require.NoError(t, err)
-	require.EqualValues(t, map[string][]string{
+	require.Equal(t, map[string][]string{
 		"linux": {"amd64", "arm64", "s390x"},
 	}, targets)
 }

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -455,7 +455,7 @@ func (c *client) ListPods(ctx context.Context, req *ListPodsRequest) (*ListPodsR
 		listOpts.FieldSelector = strings.Join(req.FieldSelectors, ",")
 	}
 
-	req.Retrier.Func = func(queryCtx context.Context) (any, error) {
+	req.Func = func(queryCtx context.Context) (any, error) {
 		return c.clientset.CoreV1().Pods(namespace).List(ctx, listOpts)
 	}
 
@@ -595,65 +595,65 @@ func (p *Pods) String() string {
 	out := new(strings.Builder)
 
 	for i := range p.Items {
-		out.WriteString(p.Items[i].ObjectMeta.Name + "\n")
-		out.WriteString(fmt.Sprintf("  Name: %s\n", p.Items[i].ObjectMeta.Name))
-		out.WriteString(fmt.Sprintf("  Namespace: %s\n", p.Items[i].ObjectMeta.Namespace))
-		out.WriteString(fmt.Sprintf("  Node Name: %s\n", p.Items[i].Spec.NodeName))
-		out.WriteString(fmt.Sprintf("  Hostname: %s\n", p.Items[i].Spec.Hostname))
-		out.WriteString(fmt.Sprintf("  Subdomain: %s\n", p.Items[i].Spec.Subdomain))
-		out.WriteString(fmt.Sprintf("  Resource Version: %s\n", p.Items[i].ObjectMeta.ResourceVersion))
-		out.WriteString(fmt.Sprintf("  Generation: %d\n", p.Items[i].ObjectMeta.Generation))
-		out.WriteString(fmt.Sprintf("  Creation Timestamp: %q\n", p.Items[i].ObjectMeta.CreationTimestamp))
+		out.WriteString(p.Items[i].Name + "\n")
+		fmt.Fprintf(out, "  Name: %s\n", p.Items[i].Name)
+		fmt.Fprintf(out, "  Namespace: %s\n", p.Items[i].Namespace)
+		fmt.Fprintf(out, "  Node Name: %s\n", p.Items[i].Spec.NodeName)
+		fmt.Fprintf(out, "  Hostname: %s\n", p.Items[i].Spec.Hostname)
+		fmt.Fprintf(out, "  Subdomain: %s\n", p.Items[i].Spec.Subdomain)
+		fmt.Fprintf(out, "  Resource Version: %s\n", p.Items[i].ResourceVersion)
+		fmt.Fprintf(out, "  Generation: %d\n", p.Items[i].Generation)
+		fmt.Fprintf(out, "  Creation Timestamp: %q\n", p.Items[i].CreationTimestamp)
 
 		if p.Items[i].Spec.OS != nil {
-			out.WriteString(fmt.Sprintf("  OS: %s\n", p.Items[i].Spec.OS.Name))
+			fmt.Fprintf(out, "  OS: %s\n", p.Items[i].Spec.OS.Name)
 		}
 
-		out.WriteString(fmt.Sprintf("  Phase: %s\n", p.Items[i].Status.Phase))
-		out.WriteString(fmt.Sprintf("  Message: %s\n", p.Items[i].Status.Message))
-		out.WriteString(fmt.Sprintf("  Reason: %s\n", p.Items[i].Status.Reason))
-		out.WriteString(fmt.Sprintf("  Scheduler Name: %s\n", p.Items[i].Spec.SchedulerName))
-		out.WriteString(fmt.Sprintf("  IP: %s\n", p.Items[i].Status.PodIP))
+		fmt.Fprintf(out, "  Phase: %s\n", p.Items[i].Status.Phase)
+		fmt.Fprintf(out, "  Message: %s\n", p.Items[i].Status.Message)
+		fmt.Fprintf(out, "  Reason: %s\n", p.Items[i].Status.Reason)
+		fmt.Fprintf(out, "  Scheduler Name: %s\n", p.Items[i].Spec.SchedulerName)
+		fmt.Fprintf(out, "  IP: %s\n", p.Items[i].Status.PodIP)
 
-		labels := p.Items[i].ObjectMeta.GetLabels()
+		labels := p.Items[i].GetLabels()
 		if len(labels) > 0 {
-			out.WriteString(fmt.Sprintln("  Labels:"))
+			fmt.Fprintln(out, "  Labels:")
 			for k, v := range labels {
-				out.WriteString(fmt.Sprintf("    %s=%s\n", k, v))
+				fmt.Fprintf(out, "    %s=%s\n", k, v)
 			}
 		}
 
 		for ic := range p.Items[i].Spec.InitContainers {
 			if ic == 0 {
-				out.WriteString(fmt.Sprintln("  Init Containers:"))
+				fmt.Fprintln(out, "  Init Containers:")
 			}
 			out.WriteString(istrings.Indent("    ", containerToString(p.Items[i].Spec.InitContainers[ic])))
 		}
 
 		for ic := range p.Items[i].Status.InitContainerStatuses {
 			if ic == 0 {
-				out.WriteString(fmt.Sprintln("  Init Container Status:"))
+				fmt.Fprintln(out, "  Init Container Status:")
 			}
 			out.WriteString(istrings.Indent("    ", contianerStatusToString(p.Items[i].Status.InitContainerStatuses[ic])))
 		}
 
 		for ic := range p.Items[i].Spec.Containers {
 			if ic == 0 {
-				out.WriteString(fmt.Sprintln("  Containers:"))
+				fmt.Fprintln(out, "  Containers:")
 			}
 			out.WriteString(istrings.Indent("    ", containerToString(p.Items[i].Spec.Containers[ic])))
 		}
 
 		for ic := range p.Items[i].Status.ContainerStatuses {
 			if ic == 0 {
-				out.WriteString(fmt.Sprintln("  Container Status:"))
+				fmt.Fprintln(out, "  Container Status:")
 			}
 			out.WriteString(istrings.Indent("    ", contianerStatusToString(p.Items[i].Status.ContainerStatuses[ic])))
 		}
 
 		for ic := range p.Items[i].Spec.EphemeralContainers {
 			if ic == 0 {
-				out.WriteString(fmt.Sprintln("  Ephemeral Containers:"))
+				fmt.Fprintln(out, "  Ephemeral Containers:")
 			}
 
 			// EphemeralContainerCommon has all the same fields as Container. We'll convert it
@@ -673,7 +673,7 @@ func (p *Pods) String() string {
 
 		for ic := range p.Items[i].Status.EphemeralContainerStatuses {
 			if ic == 0 {
-				out.WriteString(fmt.Sprintln("  Ephemeral Container Status:"))
+				fmt.Fprintln(out, "  Ephemeral Container Status:")
 			}
 			out.WriteString(istrings.Indent("    ", contianerStatusToString(p.Items[i].Status.EphemeralContainerStatuses[ic])))
 		}
@@ -685,23 +685,23 @@ func (p *Pods) String() string {
 func containerToString(container v1.Container) string {
 	out := new(strings.Builder)
 	out.WriteString(container.Name + "\n")
-	out.WriteString(fmt.Sprintf("  Name: %s\n", container.Name))
-	out.WriteString(fmt.Sprintf("  Image: %s\n", container.Image))
-	out.WriteString(fmt.Sprintf("  Command: %s\n", strings.Join(container.Command, " ")))
-	out.WriteString(fmt.Sprintln("  Args:"))
+	fmt.Fprintf(out, "  Name: %s\n", container.Name)
+	fmt.Fprintf(out, "  Image: %s\n", container.Image)
+	fmt.Fprintf(out, "  Command: %s\n", strings.Join(container.Command, " "))
+	fmt.Fprintln(out, "  Args:")
 	for c := range container.Args {
 		out.WriteString(istrings.Indent("    ", container.Args[c]))
 	}
-	out.WriteString(fmt.Sprintln(""))
-	out.WriteString(fmt.Sprintln("  Ports:"))
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "  Ports:")
 	for c := range container.Ports {
-		out.WriteString(fmt.Sprintf("    %s:\n", container.Ports[c].Name))
-		out.WriteString(fmt.Sprintf("      Host Port: %d\n", container.Ports[c].HostPort))
-		out.WriteString(fmt.Sprintf("      Container Port: %d\n", container.Ports[c].ContainerPort))
-		out.WriteString(fmt.Sprintf("      Protocol: %s\n", container.Ports[c].Protocol))
-		out.WriteString(fmt.Sprintf("      Host IP: %s\n", container.Ports[c].HostIP))
+		fmt.Fprintf(out, "    %s:\n", container.Ports[c].Name)
+		fmt.Fprintf(out, "      Host Port: %d\n", container.Ports[c].HostPort)
+		fmt.Fprintf(out, "      Container Port: %d\n", container.Ports[c].ContainerPort)
+		fmt.Fprintf(out, "      Protocol: %s\n", container.Ports[c].Protocol)
+		fmt.Fprintf(out, "      Host IP: %s\n", container.Ports[c].HostIP)
 	}
-	out.WriteString(fmt.Sprintln("  Environment:"))
+	fmt.Fprintln(out, "  Environment:")
 	for c := range container.Env {
 		name := container.Env[c].Name
 		value := container.Env[c].Value
@@ -714,10 +714,10 @@ func containerToString(container v1.Container) string {
 				sourceStr = fmt.Sprintf("%s:%s", source.ResourceFieldRef.ContainerName, source.ResourceFieldRef.Resource)
 			}
 			if source.ConfigMapKeyRef != nil {
-				sourceStr = fmt.Sprintf("%s:%s", source.ConfigMapKeyRef.LocalObjectReference.Name, source.ConfigMapKeyRef.Key)
+				sourceStr = fmt.Sprintf("%s:%s", source.ConfigMapKeyRef.Name, source.ConfigMapKeyRef.Key)
 			}
 			if source.SecretKeyRef != nil {
-				sourceStr = fmt.Sprintf("%s:%s", source.SecretKeyRef.LocalObjectReference.Name, source.SecretKeyRef.Key)
+				sourceStr = fmt.Sprintf("%s:%s", source.SecretKeyRef.Name, source.SecretKeyRef.Key)
 			}
 			if value == "" {
 				value = fmt.Sprintf("(%s)", sourceStr)
@@ -728,7 +728,7 @@ func containerToString(container v1.Container) string {
 		if name == "VAULT_LICENSE" {
 			value = "[redacted]"
 		}
-		out.WriteString(fmt.Sprintf("    %s=%s\n", name, value))
+		fmt.Fprintf(out, "    %s=%s\n", name, value)
 	}
 
 	return out.String()
@@ -737,12 +737,12 @@ func containerToString(container v1.Container) string {
 func contianerStatusToString(status v1.ContainerStatus) string {
 	out := new(strings.Builder)
 	out.WriteString(status.Name + "\n")
-	out.WriteString(fmt.Sprintf("  Name: %s\n", status.Name))
-	out.WriteString(fmt.Sprintf("  Image: %s\n", status.Image))
-	out.WriteString(fmt.Sprintf("  Image ID: %s\n", status.ImageID))
-	out.WriteString(fmt.Sprintf("  Container ID: %s\n", status.ContainerID))
-	out.WriteString(fmt.Sprintf("  Ready: %t\n", status.Ready))
-	out.WriteString(fmt.Sprintf("  Restart Count: %d\n", status.RestartCount))
+	fmt.Fprintf(out, "  Name: %s\n", status.Name)
+	fmt.Fprintf(out, "  Image: %s\n", status.Image)
+	fmt.Fprintf(out, "  Image ID: %s\n", status.ImageID)
+	fmt.Fprintf(out, "  Container ID: %s\n", status.ContainerID)
+	fmt.Fprintf(out, "  Ready: %t\n", status.Ready)
+	fmt.Fprintf(out, "  Restart Count: %d\n", status.RestartCount)
 
 	return out.String()
 }

--- a/internal/plugin/datasource_artifactory_item.go
+++ b/internal/plugin/datasource_artifactory_item.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"text/template"
 
 	"github.com/asaskevich/govalidator"
 
@@ -28,15 +29,16 @@ type artifactoryItem struct {
 var _ datarouter.DataSource = (*artifactoryItem)(nil)
 
 type artifactoryItemStateV1 struct {
-	ID         *tfString
-	Username   *tfString
-	Token      *tfString
-	Host       *tfString
-	Repo       *tfString
-	Path       *tfString
-	Name       *tfString
-	Properties *tfStringMap
-	Results    *tfObjectSlice
+	ID            *tfString
+	Username      *tfString
+	Token         *tfString
+	Host          *tfString
+	Repo          *tfString
+	Path          *tfString
+	Name          *tfString
+	Properties    *tfStringMap
+	QueryTemplate *tfString
+	Results       *tfObjectSlice
 
 	failureHandlers
 }
@@ -68,6 +70,7 @@ func newArtifactoryItemStateV1() *artifactoryItemStateV1 {
 		Path:            newTfString(),
 		Name:            newTfString(),
 		Properties:      newTfStringMap(),
+		QueryTemplate:   newTfString(),
 		Results:         results,
 		failureHandlers: failureHandlers{},
 	}
@@ -155,12 +158,41 @@ func (s *artifactoryItemStateV1) Schema() *tfprotov6.Schema {
 		Block: &tfprotov6.SchemaBlock{
 			DescriptionKind: tfprotov6.StringKindMarkdown,
 			Description: docCaretToBacktick(`
-The ^enos_artifactory_item^ datasource is a datasource that we can use to search for items in
+The ^enos_artifactory_item^ datasource is a datasource that you can use to search for items in
 artifactory. This is useful for finding build artifact URLs that we can install on targets for testing.
-The datasource will return URLs to all matching items. The more specific your search criteria, the
-fewer results you'll receive.
+The datasource will return a list of ^results^ which include ^name^s and ^url^s to all matching items.
 
-Note: the underlying implementation uses AQL to search for artifacts and uses the ^$match^ operator
+There are two primary modes for using the datasource for searching. One for a ^properties^ based match
+and another where a ^query_template^ is provided.
+
+For the ^properties^ based search, configure the datasource with a ^name^ and list of ^properties^ that
+are expected and the datasource will automatically generate a query where and search with. Each property
+is included in the ^items.find()^ query with a ^$match^ operator. The more specific your search criteria,
+via the ^path^, ^name^, and ^properties^, the fewer results you'll receive.
+
+For the ^query_template^, the ^repo^, ^path^, ^name^, and ^properties^ attributes are not automatically
+included in a query for you. Instead, you provide a Go text template which includes the entire query.
+This is an advanced option for hand crafted artisinal queries. As it is a Go template, you can provide
+pure text string or include [Go text template](https://pkg.go.dev/text/template#Template) directives.
+For the latter, you can expect the evaluation context to include an object with the following attributes:
+  - Repo          string
+  - Path          string
+  - Name          string
+  - Properties    map[string]string
+
+For example:
+^^^hcl
+query_template = <<EOQ
+items.find({
+  "repo":           { "$match": "{{ .Repo }}" },
+  "path":           { "$match": "{{ .Path }}" },
+  "name":           { "$match": "{{ .Name }}" },
+  "stat.downloads": { "$gt": "${var.min_download} "}
+}).include("*", "property.*") .sort({"$desc": ["modified"]})
+EOQ
+^^^
+
+*NOTE*: The underlying implementation uses AQL to search for artifacts and uses the ^$match^ operator
 for every criteria. This means that you can use wildcards ^*^ for any field. See the [AQL developer guide](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Query+Language) for more information.
 `),
 			Attributes: []*tfprotov6.SchemaAttribute{
@@ -214,6 +246,12 @@ for every criteria. This means that you can use wildcards ^*^ for any field. See
 					Description: "A map of properties to match on",
 				},
 				{
+					Name:        "query_template",
+					Type:        tftypes.String,
+					Optional:    true,
+					Description: "An AQL query to run. When a 'query' is provided all search properties are ignored so you must write the a complete and valid items.find() query",
+				},
+				{
 					Name:            "results",
 					Type:            s.Results.TFType(),
 					Computed:        true,
@@ -246,21 +284,35 @@ func (s *artifactoryItemStateV1) Validate(ctx context.Context) error {
 		}
 	}
 
+	if !s.QueryTemplate.Unknown {
+		templ, ok := s.QueryTemplate.Get()
+		if ok && templ != "" {
+			_, err := template.New("query").Parse(templ)
+			if err != nil {
+				return ValidationError(
+					fmt.Sprintf("invalid query template: %s", err.Error()),
+					"query_template",
+				)
+			}
+		}
+	}
+
 	return nil
 }
 
 // FromTerraform5Value is a callback to unmarshal from the		tftypes.Vault with As().
 func (s *artifactoryItemStateV1) FromTerraform5Value(val tftypes.Value) error {
 	_, err := mapAttributesTo(val, map[string]interface{}{
-		"id":         s.ID,
-		"username":   s.Username,
-		"token":      s.Token,
-		"host":       s.Host,
-		"repo":       s.Repo,
-		"path":       s.Path,
-		"name":       s.Name,
-		"properties": s.Properties,
-		"results":    s.Results,
+		"id":             s.ID,
+		"username":       s.Username,
+		"token":          s.Token,
+		"host":           s.Host,
+		"repo":           s.Repo,
+		"path":           s.Path,
+		"name":           s.Name,
+		"properties":     s.Properties,
+		"query_template": s.QueryTemplate,
+		"results":        s.Results,
 	})
 
 	return err
@@ -269,30 +321,32 @@ func (s *artifactoryItemStateV1) FromTerraform5Value(val tftypes.Value) error {
 // Terraform5Type is the file state tftypes.Type.
 func (s *artifactoryItemStateV1) Terraform5Type() tftypes.Type {
 	return tftypes.Object{AttributeTypes: map[string]tftypes.Type{
-		"id":         s.ID.TFType(),
-		"username":   s.Username.TFType(),
-		"token":      s.Token.TFType(),
-		"host":       s.Host.TFType(),
-		"repo":       s.Repo.TFType(),
-		"path":       s.Path.TFType(),
-		"name":       s.Name.TFType(),
-		"properties": s.Properties.TFType(),
-		"results":    s.Results.TFType(),
+		"id":             s.ID.TFType(),
+		"username":       s.Username.TFType(),
+		"token":          s.Token.TFType(),
+		"host":           s.Host.TFType(),
+		"repo":           s.Repo.TFType(),
+		"path":           s.Path.TFType(),
+		"name":           s.Name.TFType(),
+		"properties":     s.Properties.TFType(),
+		"query_template": s.QueryTemplate.TFType(),
+		"results":        s.Results.TFType(),
 	}}
 }
 
 // Terraform5Value is the file state tftypes.Value.
 func (s *artifactoryItemStateV1) Terraform5Value() tftypes.Value {
 	return tftypes.NewValue(s.Terraform5Type(), map[string]tftypes.Value{
-		"id":         s.ID.TFValue(),
-		"username":   s.Username.TFValue(),
-		"token":      s.Token.TFValue(),
-		"host":       s.Host.TFValue(),
-		"repo":       s.Repo.TFValue(),
-		"path":       s.Path.TFValue(),
-		"name":       s.Name.TFValue(),
-		"properties": s.Properties.TFValue(),
-		"results":    s.Results.TFValue(),
+		"id":             s.ID.TFValue(),
+		"username":       s.Username.TFValue(),
+		"token":          s.Token.TFValue(),
+		"host":           s.Host.TFValue(),
+		"repo":           s.Repo.TFValue(),
+		"path":           s.Path.TFValue(),
+		"name":           s.Name.TFValue(),
+		"properties":     s.Properties.TFValue(),
+		"query_template": s.QueryTemplate.TFValue(),
+		"results":        s.Results.TFValue(),
 	})
 }
 
@@ -324,6 +378,17 @@ func (s *artifactoryItemStateV1) Search(ctx context.Context) error {
 	if props, ok := s.Properties.GetStrings(); ok {
 		reqArgs = append(reqArgs, artifactory.WithProperties(props))
 	}
+	if query, ok := s.QueryTemplate.Get(); ok {
+		if ok && query != "" {
+			t, err := template.New("query").Parse(query)
+			if err != nil {
+				return fmt.Errorf("search failed: invalid query template: %w", err)
+			}
+
+			reqArgs = append(reqArgs, artifactory.WithLimit("1"))
+			reqArgs = append(reqArgs, artifactory.WithQueryTemplate(t))
+		}
+	}
 
 	req := artifactory.NewSearchAQLRequest(reqArgs...)
 	res, err := client.SearchAQL(ctx, req)
@@ -345,7 +410,7 @@ func (s *artifactoryItemStateV1) Search(ctx context.Context) error {
 		resSize := newTfString()
 		resSize.Set(result.Size.String())
 
-		r.Set(map[string]interface{}{
+		r.Set(map[string]any{
 			"name":   resName,
 			"type":   resType,
 			"url":    resURL,

--- a/internal/plugin/datasource_artifactory_item.go
+++ b/internal/plugin/datasource_artifactory_item.go
@@ -290,7 +290,7 @@ func (s *artifactoryItemStateV1) Validate(ctx context.Context) error {
 			_, err := template.New("query").Parse(templ)
 			if err != nil {
 				return ValidationError(
-					fmt.Sprintf("invalid query template: %s", err.Error()),
+					"invalid query template: "+err.Error(),
 					"query_template",
 				)
 			}

--- a/internal/plugin/datasource_artifactory_item_test.go
+++ b/internal/plugin/datasource_artifactory_item_test.go
@@ -15,40 +15,48 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// TestAccDataSourceArtifacotoryItem is an integration test that uses the
+// TestAccDataSourceArtifacotoryItemProperties is an integration test that uses the
 // actual HashiCorp artifactory service to resolve items based on the search
 // criteria.
 //
 //nolint:paralleltest// because our resource handles it
-func TestAccDataSourceArtifactoryItem(t *testing.T) {
-	state := newArtifactoryItemStateV1()
-	_, okacc := os.LookupEnv("TF_ACC")
-	username, _ := os.LookupEnv("ARTIFACTORY_USER")
-	token, oktoken := os.LookupEnv("ARTIFACTORY_TOKEN")
+func TestAccDataSourceArtifacotoryItemProperties(t *testing.T) {
+	for name, props := range map[string]map[string]string{
+		"vault-1.18.5-1.x86_64.rpm": {
+			"commit":          "06a36557c4904c52f720bafb71866d389385f5ad",
+			"product-name":    "vault",
+			"product-version": "1.18.5",
+		},
+		"vault-1.19.1-1.x86_64.rpm": {
+			"build.number": "69bb3e9e943962d8fc2aa8a12031d35d2aac9a68",
+			"build.name":   "vault-1.19.1",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := newArtifactoryItemStateV1()
+			_, okacc := os.LookupEnv("TF_ACC")
+			username, _ := os.LookupEnv("ARTIFACTORY_USER")
+			token, oktoken := os.LookupEnv("ARTIFACTORY_TOKEN")
 
-	if !okacc || !oktoken {
-		t.Log(`skipping data "enos_artifactory_item" test because either TF_ACC or ARTIFACTORY_TOKEN are not set`)
-		t.Skip()
+			if !okacc || !oktoken {
+				t.Log(`skipping data "enos_artifactory_item" test because either TF_ACC or ARTIFACTORY_TOKEN are not set`)
+				t.Skip()
 
-		return
-	}
+				return
+			}
 
-	state.Username.Set(username)
-	state.Token.Set(token)
-	state.Host.Set("https://artifactory.hashicorp.engineering/artifactory")
-	state.Repo.Set("hashicorp-crt-stable-local*")
-	state.Path.Set("vault/*")
-	state.Name.Set("vault_1.15.4-1_arm64.deb")
-	state.Properties.SetStrings(map[string]string{
-		"commit":          "818455b6d8db30c219a13560fa699f5566a0d898",
-		"product-name":    "vault",
-		"product-version": "1.15.4",
-	})
+			state.Username.Set(username)
+			state.Token.Set(token)
+			state.Host.Set("https://artifactory.hashicorp.engineering/artifactory")
+			state.Repo.Set("hashicorp-crt-stable-local*")
+			state.Path.Set("vault/*")
+			state.Name.Set(name)
+			state.Properties.SetStrings(props)
 
-	cfg := template.Must(template.New("enos_data_artifactory_item").Parse(`data "enos_artifactory_item" "vault" {
-	{{if .Username.Value -}}
+			cfg := template.Must(template.New("enos_data_artifactory_item").Parse(`data "enos_artifactory_item" "vault" {
+  {{if .Username.Value -}}
   username = "{{ .Username.Value }}"
-	{{end -}}
+  {{end -}}
   token    = "{{ .Token.Value }}"
 
   host = "{{ .Host.Value }}"
@@ -58,30 +66,129 @@ func TestAccDataSourceArtifactoryItem(t *testing.T) {
 
   {{ if .Properties.StringValue -}}
   properties = {
-	{{ range $k, $v := .Properties.StringValue -}}
+  {{ range $k, $v := .Properties.StringValue -}}
     "{{ $k }}" = "{{ $v }}"
-	{{ end -}}
+  {{ end -}}
   }
   {{ end -}}
 }
 
-output "url" {
+output "name" {
   value = data.enos_artifactory_item.vault.results[0].name
+}`))
+
+			buf := bytes.Buffer{}
+			require.NoError(t, cfg.Execute(&buf, state))
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: testProviders(t),
+				Steps: []resource.TestStep{
+					{
+						Config: buf.String(),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchOutput("name", regexp.MustCompile(name)),
+						),
+					},
+				},
+			})
+		})
+	}
 }
-`))
 
-	buf := bytes.Buffer{}
-	require.NoError(t, cfg.Execute(&buf, state))
+// TestAccDataSourceArtifacotoryItemQueryTemplate is an integration test that
+// uses the actual HashiCorp artifactory service to resolve items based on the
+// search criteria.
+//
+//nolint:paralleltest// because our resource handles it
+func TestAccDataSourceArtifacotoryItemQueryTemplate(t *testing.T) {
+	orQueryTemplate := template.Must(template.New("or").Parse(`
+items.find(
+{
+  "$or": [
+    {
+      "$and":
+      [
+        {"@commit": { "$match": "{{ .SHA }}" }},
+        {"@product-name": { "$match": "vault" }},
+        {"repo": { "$match": "hashicorp-crt-stable-local*" }},
+        {"path": { "$match": "vault/*" }},
+        {"name": { "$match": "{{ .Name }}"}}
+      ]
+    },
+    {
+      "$and":
+      [
+        {"@build.number": { "$match": "{{ .SHA }}" }},
+        {"@build.name": { "$match": "vault" }},
+        {"repo": { "$match": "hashicorp-crt-stable-local*" }},
+        {"path": { "$match": "vault/*" }},
+        {"name": { "$match": "{{ .Name }}"}}
+      ]
+    }
+  ]
+}).include("*", "property.*") .sort({"$desc": ["modified"]})`))
 
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testProviders(t),
-		Steps: []resource.TestStep{
-			{
-				Config: buf.String(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchOutput("url", regexp.MustCompile(`.deb`)),
-				),
-			},
-		},
-	})
+	for name, sha := range map[string]string{
+		// New CRT fields
+		"vault_1.19.1-1_amd64.deb": "aa75903ec499b2236da9e7bbbfeb7fd16fa4fd9d",
+		// Old CRT fields
+		"vault_1.19.0-1_amd64.deb": "ea8260c5893f2f38c3daa7aed07e89d85613844f",
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := newArtifactoryItemStateV1()
+			_, okacc := os.LookupEnv("TF_ACC")
+			username, _ := os.LookupEnv("ARTIFACTORY_USER")
+			token, oktoken := os.LookupEnv("ARTIFACTORY_TOKEN")
+
+			if !okacc || !oktoken {
+				t.Log(`skipping data "enos_artifactory_item" test because either TF_ACC or ARTIFACTORY_TOKEN are not set`)
+				t.Skip()
+
+				return
+			}
+
+			qbuf := &bytes.Buffer{}
+			err := orQueryTemplate.Execute(qbuf, struct {
+				SHA  string
+				Name string
+			}{
+				SHA:  sha,
+				Name: name,
+			})
+			require.NoError(t, err)
+
+			state.Username.Set(username)
+			state.Token.Set(token)
+			state.Host.Set("https://artifactory.hashicorp.engineering/artifactory")
+			state.QueryTemplate.Set(qbuf.String())
+
+			cfg := template.Must(template.New("enos_data_artifactory_item").Parse(`data "enos_artifactory_item" "vault" {
+  username = "{{ .Username.Value }}"
+  token    = "{{ .Token.Value }}"
+  host     = "{{ .Host.Value }}"
+  query_template = <<EOT
+{{ .QueryTemplate.Value }}
+  EOT
+}
+
+output "name" {
+  value = data.enos_artifactory_item.vault.results[0].name
+}`))
+
+			buf := bytes.Buffer{}
+			require.NoError(t, cfg.Execute(&buf, state))
+
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: testProviders(t),
+				Steps: []resource.TestStep{
+					{
+						Config: buf.String(),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchOutput("name", regexp.MustCompile(name)),
+						),
+					},
+				},
+			})
+		})
+	}
 }

--- a/internal/plugin/embedded_transport_test.go
+++ b/internal/plugin/embedded_transport_test.go
@@ -157,12 +157,12 @@ func TestProviderEmbeddedTransportFromTFValue(t *testing.T) {
 
 			transport := newEmbeddedTransport()
 			require.NoError(t, transport.FromTerraform5Value(test.config.toTFValue(t)))
-			assert.Equal(tt, len(expectedValues), len(transport.CopyValues()))
-			assert.Equal(tt, len(expectedAttributeValues), len(transport.Attributes()))
+			assert.Len(tt, transport.CopyValues(), len(expectedValues))
+			assert.Len(tt, transport.Attributes(), len(expectedAttributeValues))
 
 			for transportType, actualValues := range transport.CopyValues() {
 				expectedValues := expectedValues[transportType]
-				assert.Equal(tt, len(expectedValues), len(actualValues))
+				assert.Len(tt, actualValues, len(expectedValues))
 				for name, expectedValue := range expectedValues {
 					actualStringValue := ""
 					actualValue, ok := actualValues[name]
@@ -175,13 +175,13 @@ func TestProviderEmbeddedTransportFromTFValue(t *testing.T) {
 
 			for transportType, actualValues := range transport.Attributes() {
 				expectedTransportValues := expectedAttributeValues[transportType]
-				assert.Equal(tt, len(expectedTransportValues), len(actualValues))
+				assert.Len(tt, actualValues, len(expectedTransportValues))
 				for name, expectedValue := range expectedTransportValues {
 					actualValue, ok := actualValues[name].(*tfString).Get()
 					if ok {
 						assert.Equal(tt, expectedValue, actualValue)
 					} else {
-						assert.Equal(tt, "", actualValue)
+						assert.Empty(tt, actualValue)
 					}
 				}
 			}
@@ -278,7 +278,7 @@ func TestProviderEmbeddedTransportApplyDefaults(t *testing.T) {
 
 				for tType, expectedConfig := range test.expectedValues {
 					actualConfig := transport.Attributes()[tType]
-					assert.Equal(tt, len(actualConfig), len(expectedConfig))
+					assert.Len(tt, actualConfig, len(expectedConfig))
 					for name, expectedValue := range expectedConfig {
 						assert.Equal(tt, expectedValue, actualConfig[name].(*tfString).Val)
 					}

--- a/internal/plugin/helpers_test.go
+++ b/internal/plugin/helpers_test.go
@@ -216,7 +216,7 @@ func ensureEnosTransportEnvVars(t *testing.T) (map[string]string, bool) {
 	vars["host"], okhost = os.LookupEnv("ENOS_TRANSPORT_HOST")
 	vars["path"], okpath = os.LookupEnv("ENOS_TRANSPORT_PRIVATE_KEY_PATH")
 
-	if !(okacc && okuser && okhost && okpath) {
+	if !okacc || !okuser || !okhost || !okpath {
 		t.Log(`skipping because TF_ACC, ENOS_TRANSPORT_USER, ENOS_TRANSPORT_HOST, and ENOS_TRANSPORT_PRIVATE_KEY_PATH environment variables need to be set`)
 		t.Skip()
 

--- a/internal/plugin/ip_resolver_test.go
+++ b/internal/plugin/ip_resolver_test.go
@@ -117,7 +117,7 @@ func TestPublicIPAddressResolver_add_ips(t *testing.T) {
 	sort.Sort(byIP(gotV6))
 	sort.Sort(byIP(gotAll))
 
-	require.EqualValues(t, expectedV4, gotV4)
-	require.EqualValues(t, expectedV6, gotV6)
-	require.EqualValues(t, expectedAll, gotAll)
+	require.Equal(t, expectedV4, gotV4)
+	require.Equal(t, expectedV6, gotV6)
+	require.Equal(t, expectedAll, gotAll)
 }

--- a/internal/plugin/resource_bundle_install_test.go
+++ b/internal/plugin/resource_bundle_install_test.go
@@ -162,7 +162,7 @@ func TestAccResourceBundleInstall(t *testing.T) {
 
 		artUser, okuser := os.LookupEnv("ARTIFACTORY_USER")
 		artToken, oktoken := os.LookupEnv("ARTIFACTORY_TOKEN")
-		if !(oktoken && okuser) {
+		if !oktoken || !okuser {
 			t.Log(`skipping data bundle install from artifactory test because TF_ACC, ARTIFACTORY_TOKEN, ARTIFACTORY_USER aren't set`)
 			t.Skip()
 		} else {

--- a/internal/plugin/resource_vault_start_test.go
+++ b/internal/plugin/resource_vault_start_test.go
@@ -437,7 +437,7 @@ func Test_sealAttrsToEnvVars(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			require.EqualValues(t, test.expected, got)
+			require.Equal(t, test.expected, got)
 		})
 	}
 }

--- a/internal/remoteflight/boundary/init.go
+++ b/internal/remoteflight/boundary/init.go
@@ -148,9 +148,9 @@ func (r *InitRequest) Validate() error {
 // String returns the init request as an init command.
 func (r *InitRequest) String() string {
 	cmd := &strings.Builder{}
-	cmd.WriteString(fmt.Sprintf("%s/%s database init -format json", r.BinPath, r.BinName))
+	fmt.Fprintf(cmd, "%s/%s database init -format json", r.BinPath, r.BinName)
 	// TODO: add the other init options for upgrades
-	cmd.WriteString(fmt.Sprintf(" -config=%s/boundary.hcl", r.ConfigPath))
+	fmt.Fprintf(cmd, " -config=%s/boundary.hcl", r.ConfigPath)
 
 	return cmd.String()
 }

--- a/internal/remoteflight/consul/agent_host.go
+++ b/internal/remoteflight/consul/agent_host.go
@@ -92,7 +92,7 @@ func GetAgentHost(ctx context.Context, tr it.Transport, req *AgentHostRequest) (
 		))
 
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 
 		if stderr != "" {

--- a/internal/remoteflight/consul/checks.go
+++ b/internal/remoteflight/consul/checks.go
@@ -14,7 +14,7 @@ import (
 // has all of the properties and values we expect for a service to be running.
 func CheckStateHasSystemdEnabledAndRunningProperties() CheckStater {
 	return func(s *State) error {
-		props, err := s.UnitProperties.FindProperties(systemd.EnabledAndRunningProperties)
+		props, err := s.FindProperties(systemd.EnabledAndRunningProperties)
 		if err != nil {
 			return fmt.Errorf("expected consul systemd unit to be enabled and running, got: %s", err)
 		}
@@ -49,11 +49,11 @@ func CheckStateNodeIsHealthy() CheckStater {
 // CheckStateClusterHasLeader checks whether or not the consul cluster has a leader.
 func CheckStateClusterHasLeader() CheckStater {
 	return func(s *State) error {
-		if s.RaftConfigurationResponse == nil || s.RaftConfigurationResponse.Servers == nil {
+		if s.RaftConfigurationResponse == nil || s.Servers == nil {
 			return errors.New("no raft servers were found in state")
 		}
 
-		for i := range s.RaftConfigurationResponse.Servers {
+		for i := range s.Servers {
 			if s.RaftConfigurationResponse.Servers[i].Leader {
 				return nil
 			}
@@ -94,12 +94,12 @@ func CheckStateClusterHasMinNHealthyNodes(min uint) CheckStater {
 // N raft voters.
 func CheckStateClusterHasMinNVoters(min uint) CheckStater {
 	return func(s *State) error {
-		if s.RaftConfigurationResponse == nil || s.RaftConfigurationResponse.Servers == nil {
+		if s.RaftConfigurationResponse == nil || s.Servers == nil {
 			return errors.New("no raft servers were found in state")
 		}
 
 		voters := uint(0)
-		for i := range s.RaftConfigurationResponse.Servers {
+		for i := range s.Servers {
 			if s.RaftConfigurationResponse.Servers[i].Voter {
 				voters++
 			}

--- a/internal/remoteflight/consul/checks_test.go
+++ b/internal/remoteflight/consul/checks_test.go
@@ -248,8 +248,8 @@ func TestStateClusterHasMinNVoters(t *testing.T) {
 				state := NewState()
 				state.RaftConfigurationResponse = &RaftConfigurationResponse{Servers: make([]*RaftServer, 0)}
 				require.NoError(t, json.Unmarshal(content, &state.RaftConfigurationResponse))
-				cpy := *state.RaftConfigurationResponse.Servers[0]
-				state.RaftConfigurationResponse.Servers = append(state.RaftConfigurationResponse.Servers, &cpy)
+				cpy := *state.Servers[0]
+				state.Servers = append(state.Servers, &cpy)
 
 				return state
 			},

--- a/internal/remoteflight/consul/health_node.go
+++ b/internal/remoteflight/consul/health_node.go
@@ -111,7 +111,7 @@ func GetHealthNode(ctx context.Context, tr it.Transport, req *HealthNodeRequest)
 		))
 
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 
 		if stderr != "" {
@@ -156,19 +156,19 @@ func (n *NodeHealth) String() string {
 	out := new(strings.Builder)
 
 	if n.Node != "" {
-		out.WriteString(fmt.Sprintf("Node: %s\n", n.Node))
+		fmt.Fprintf(out, "Node: %s\n", n.Node)
 	}
 
 	if n.Status != "" {
-		out.WriteString(fmt.Sprintf("Status: %s\n", n.Status))
+		fmt.Fprintf(out, "Status: %s\n", n.Status)
 	}
 
 	if n.Output != "" {
-		out.WriteString(fmt.Sprintf("Output: %s\n", n.Output))
+		fmt.Fprintf(out, "Output: %s\n", n.Output)
 	}
 
 	if n.Notes != "" {
-		out.WriteString(fmt.Sprintf("Notes: %s\n", n.Notes))
+		fmt.Fprintf(out, "Notes: %s\n", n.Notes)
 	}
 
 	return out.String()

--- a/internal/remoteflight/consul/health_state_passing.go
+++ b/internal/remoteflight/consul/health_state_passing.go
@@ -87,7 +87,7 @@ func GetHealthStatePassing(ctx context.Context, tr it.Transport, req *HealthStat
 		))
 
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 
 		if stderr != "" {

--- a/internal/remoteflight/consul/raft_configuration.go
+++ b/internal/remoteflight/consul/raft_configuration.go
@@ -98,7 +98,7 @@ func GetRaftConfiguration(ctx context.Context, tr it.Transport, req *RaftConfigu
 		))
 
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 
 		if stderr != "" {
@@ -135,7 +135,7 @@ func (r *RaftConfigurationResponse) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintln("Servers"))
+	_, _ = fmt.Fprintln(out, "Servers")
 	for i := range r.Servers {
 		_, _ = out.WriteString(istrings.Indent("  ", r.Servers[i].String()))
 	}
@@ -150,12 +150,12 @@ func (s *RaftServer) String() string {
 	}
 
 	out := new(strings.Builder)
-	out.WriteString(fmt.Sprintf("Node: %s\n", s.Node))
-	out.WriteString(fmt.Sprintf("ID: %s\n", s.ID))
-	out.WriteString(fmt.Sprintf("Address: %s\n", s.Address))
-	out.WriteString(fmt.Sprintf("Leader: %t\n", s.Leader))
-	out.WriteString(fmt.Sprintf("ProtocolVersion: %s\n", s.ProtocolVersion))
-	out.WriteString(fmt.Sprintf("Voter: %t\n", s.Voter))
+	fmt.Fprintf(out, "Node: %s\n", s.Node)
+	fmt.Fprintf(out, "ID: %s\n", s.ID)
+	fmt.Fprintf(out, "Address: %s\n", s.Address)
+	fmt.Fprintf(out, "Leader: %t\n", s.Leader)
+	fmt.Fprintf(out, "ProtocolVersion: %s\n", s.ProtocolVersion)
+	fmt.Fprintf(out, "Voter: %t\n", s.Voter)
 
 	return out.String()
 }

--- a/internal/remoteflight/consul/state.go
+++ b/internal/remoteflight/consul/state.go
@@ -155,7 +155,7 @@ func GetState(ctx context.Context, tr it.Transport, req *StateRequest) (*State, 
 		ctx, tr, NewHealthNodeRequest(
 			WithHealthNodeRequestFlightControlPath(fcRes.Path),
 			WithHealthNodeRequestConsulAddr(req.ConsulAddr),
-			WithHealthNodeRequestNodeName(state.AgentHostResponse.Hostname()),
+			WithHealthNodeRequestNodeName(state.Hostname()),
 		),
 	)
 	if err != nil {
@@ -242,7 +242,7 @@ func WaitForState(ctx context.Context, tr it.Transport, req *StateRequest, check
 func (s *State) String() string {
 	out := new(strings.Builder)
 
-	_, _ = out.WriteString(fmt.Sprintf("Agent Hostname: %s\n", s.AgentHostResponse.Hostname()))
+	_, _ = fmt.Fprintf(out, "Agent Hostname: %s\n", s.Hostname())
 	s.printStateField(out, s.HealthNodeResponse, "Node Health")
 	s.printStateField(out, s.HealthStatePassingResponse, "Healthy Nodes")
 	s.printStateField(out, s.RaftConfigurationResponse, "Raft Configuration")
@@ -250,7 +250,7 @@ func (s *State) String() string {
 	// Most of the time we don't care about all of the systemd unit properties.
 	// Try and find our meaningful status properties. If we can't then something
 	// strange is afoot and we'll display all of our props.
-	props, err := s.UnitProperties.FindProperties(systemd.EnabledAndRunningProperties)
+	props, err := s.FindProperties(systemd.EnabledAndRunningProperties)
 	if err != nil {
 		props = s.UnitProperties
 	}
@@ -270,5 +270,5 @@ func (s *State) printStateField(w io.Writer, f fmt.Stringer, fn string) {
 	if fs == "" {
 		return
 	}
-	_, _ = w.Write([]byte(fmt.Sprintf("%s: \n%s\n", fn, istrings.Indent("  ", fs))))
+	_, _ = fmt.Fprintf(w, "%s: \n%s\n", fn, istrings.Indent("  ", fs))
 }

--- a/internal/remoteflight/flightcontrol.go
+++ b/internal/remoteflight/flightcontrol.go
@@ -155,9 +155,9 @@ func InstallFlightControl(ctx context.Context, tr transport.Transport, ir *Insta
 		WithCopyFileDestination(path),
 		WithCopyFileChmod("+x"),
 		WithCopyFileRetryOptions(
-			retry.WithMaxRetries(ir.Retrier.MaxRetries),
-			retry.WithIntervalFunc(ir.Retrier.RetryInterval),
-			retry.WithOnlyRetryErrors(ir.Retrier.OnlyRetryError...),
+			retry.WithMaxRetries(ir.MaxRetries),
+			retry.WithIntervalFunc(ir.RetryInterval),
+			retry.WithOnlyRetryErrors(ir.OnlyRetryError...),
 		),
 	))
 	if err != nil {

--- a/internal/remoteflight/systemd/client.go
+++ b/internal/remoteflight/systemd/client.go
@@ -248,7 +248,7 @@ func (c *client) ShowProperties(ctx context.Context, unit string) (UnitPropertie
 		var err1 error
 		props, err1 = decodeUnitPropertiesFromShow(res.Stdout)
 		if err1 != nil {
-			err = errors.Join(err, fmt.Errorf("%w: properties: %s", err, props))
+			err = fmt.Errorf("%w: properties: %s", err1, props)
 		}
 	}
 

--- a/internal/remoteflight/systemd/properties.go
+++ b/internal/remoteflight/systemd/properties.go
@@ -77,7 +77,7 @@ func (s UnitProperties) String() string {
 	out := new(strings.Builder)
 
 	for name, value := range s {
-		_, _ = out.WriteString(fmt.Sprintf("%s=%s\n", name, value))
+		_, _ = fmt.Fprintf(out, "%s=%s\n", name, value)
 	}
 
 	return out.String()

--- a/internal/remoteflight/systemd/systemctl.go
+++ b/internal/remoteflight/systemd/systemctl.go
@@ -181,7 +181,7 @@ func (c *SystemctlCommandReq) String() (string, error) {
 	case SystemctlSubCommandKill:
 		cmd.WriteString("kill " + unitName)
 	case SystemctlSubCommandListUnits:
-		cmd.WriteString(fmt.Sprintf("list-units -t %s", c.Type))
+		fmt.Fprintf(cmd, "list-units -t %s", c.Type)
 	case SystemctlSubCommandReload:
 		cmd.WriteString("reload " + unitName)
 	case SystemctlSubCommandRestart:

--- a/internal/remoteflight/systemd/unit.go
+++ b/internal/remoteflight/systemd/unit.go
@@ -136,9 +136,9 @@ func (s Unit) ToIni() (string, error) {
 			continue
 		}
 
-		unit.WriteString(fmt.Sprintf("[%s]\n", stanza))
+		fmt.Fprintf(unit, "[%s]\n", stanza)
 		for k, v := range fields {
-			unit.WriteString(fmt.Sprintf("%s=%s\n", k, v))
+			fmt.Fprintf(unit, "%s=%s\n", k, v)
 		}
 
 		unit.WriteString("\n")

--- a/internal/remoteflight/target.go
+++ b/internal/remoteflight/target.go
@@ -83,7 +83,7 @@ func WithTargetRequestRetryOpts(opts ...retry.RetrierOpt) TargetRequestOpt {
 
 // TargetArchitecture is a helper that determines the targets architecture.
 func TargetArchitecture(ctx context.Context, tr transport.Transport, req *TargetRequest) (string, error) {
-	req.Retrier.Func = func(ctx context.Context) (any, error) {
+	req.Func = func(ctx context.Context) (any, error) {
 		arch, stderr, err := tr.Run(ctx, command.New("uname -m"))
 		if err != nil {
 			return "", fmt.Errorf("determining target host architecture: %w, STDERR:%s", err, stderr)
@@ -106,7 +106,7 @@ func TargetArchitecture(ctx context.Context, tr transport.Transport, req *Target
 
 // TargetDistro is a helper that determines the targets distribution.
 func TargetDistro(ctx context.Context, tr transport.Transport, req *TargetRequest) (string, error) {
-	req.Retrier.Func = func(ctx context.Context) (any, error) {
+	req.Func = func(ctx context.Context) (any, error) {
 		var errs error
 
 		// Try /etc/os-release
@@ -141,7 +141,7 @@ func TargetDistro(ctx context.Context, tr transport.Transport, req *TargetReques
 
 // TargetDistroVersion is a helper that determines the targets distribution version.
 func TargetDistroVersion(ctx context.Context, tr transport.Transport, req *TargetRequest) (string, error) {
-	req.Retrier.Func = func(ctx context.Context) (any, error) {
+	req.Func = func(ctx context.Context) (any, error) {
 		var errs error
 
 		// Try /etc/os-release
@@ -176,7 +176,7 @@ func TargetDistroVersion(ctx context.Context, tr transport.Transport, req *Targe
 
 // TargetHomeDir is a helper that determines the targets HOME directory.
 func TargetHomeDir(ctx context.Context, tr transport.Transport, req *TargetRequest) (string, error) {
-	req.Retrier.Func = func(ctx context.Context) (any, error) {
+	req.Func = func(ctx context.Context) (any, error) {
 		var err error
 
 		// Try the env variable
@@ -262,7 +262,7 @@ func TargetHostInfo(ctx context.Context, tr transport.Transport, req *TargetRequ
 
 // TargetHostname is a helper that determines the targets hostname.
 func TargetHostname(ctx context.Context, tr transport.Transport, req *TargetRequest) (string, error) {
-	req.Retrier.Func = func(ctx context.Context) (any, error) {
+	req.Func = func(ctx context.Context) (any, error) {
 		hostname, stderr, err := tr.Run(ctx, command.New("uname -n"))
 		if err != nil {
 			return "", fmt.Errorf("determining target hostname: %w, STDERR: %s", err, stderr)
@@ -285,7 +285,7 @@ func TargetHostname(ctx context.Context, tr transport.Transport, req *TargetRequ
 
 // TargetPlatform is a helper that determines the targets platform.
 func TargetPlatform(ctx context.Context, tr transport.Transport, req *TargetRequest) (string, error) {
-	req.Retrier.Func = func(ctx context.Context) (any, error) {
+	req.Func = func(ctx context.Context) (any, error) {
 		platform, stderr, err := tr.Run(ctx, command.New("uname -s"))
 		if err != nil {
 			return "", fmt.Errorf("determining target host platform: %w: STDERR: %s", err, stderr)
@@ -308,7 +308,7 @@ func TargetPlatform(ctx context.Context, tr transport.Transport, req *TargetRequ
 
 // TargetPlatformVersion is a helper that determines the targets platform version.
 func TargetPlatformVersion(ctx context.Context, tr transport.Transport, req *TargetRequest) (string, error) {
-	req.Retrier.Func = func(ctx context.Context) (any, error) {
+	req.Func = func(ctx context.Context) (any, error) {
 		version, stderr, err := tr.Run(ctx, command.New("uname -r"))
 		if err != nil {
 			return "", fmt.Errorf("determining target host platform version: %w: STDERR: %s", err, stderr)
@@ -336,7 +336,7 @@ func TargetProcessManager(ctx context.Context, tp transport.Transport, req *Targ
 		// Assume that were hitting a machine that doesn't have busybox ps and
 		// supports the p flag. We could theoretically use /proc/ps/stat for
 		// linux machines that have unsable ps but this is okay for now.
-		req.Retrier.Func = func(ctx context.Context) (any, error) {
+		req.Func = func(ctx context.Context) (any, error) {
 			pid1, stderr, err := tp.Run(ctx, command.New("ps -p 1 -c -o command="))
 			if err != nil {
 				return "", fmt.Errorf("failed to determine target process manager: %w: STDERR: %s", err, stderr)

--- a/internal/remoteflight/vault/checks.go
+++ b/internal/remoteflight/vault/checks.go
@@ -55,7 +55,7 @@ func CheckStateAllPodsHavePhase(phase v1.PodPhase) CheckStater {
 		for i := range s.PodList.Pods.Items {
 			if s.PodList.Pods.Items[i].Status.Phase != phase {
 				err = errors.Join(err, fmt.Errorf("expected pod %s to have phase %s, got %s, message: %s, reason: %s",
-					s.PodList.Pods.Items[i].ObjectMeta.Name,
+					s.PodList.Pods.Items[i].Name,
 					phase,
 					s.PodList.Pods.Items[i].Status.Phase,
 					s.PodList.Pods.Items[i].Status.Message,

--- a/internal/remoteflight/vault/config_state.go
+++ b/internal/remoteflight/vault/config_state.go
@@ -114,7 +114,7 @@ func GetConfigStateSanitized(ctx context.Context, tr it.Transport, req *CLIReque
 			command.WithEnvVar("VAULT_TOKEN", req.Token),
 		))
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 		if stderr != "" {
 			err = errors.Join(err, fmt.Errorf("unexpected write to stderr: %s", stderr))
@@ -152,45 +152,45 @@ func (s *ConfigStateSanitizedResponseData) String() string {
 
 	out := new(strings.Builder)
 
-	_, _ = out.WriteString(fmt.Sprintf("API Addr: %s\n", s.APIAddr))
-	_, _ = out.WriteString(fmt.Sprintf("Cache Size: %s\n", s.CacheSize))
-	_, _ = out.WriteString(fmt.Sprintf("Cluster Addr: %s\n", s.ClusterAddr))
-	_, _ = out.WriteString(fmt.Sprintf("Cluster Cipher Suites: %s\n", s.ClusterCipherSuites))
-	_, _ = out.WriteString(fmt.Sprintf("Cluster Name: %s\n", s.ClusterName))
-	_, _ = out.WriteString(fmt.Sprintf("Default Lease TTL: %s\n", s.DefaultLeaseTTL))
-	_, _ = out.WriteString(fmt.Sprintf("Default Max Request Duration: %s\n", s.DefaultMaxRequestDuration))
-	_, _ = out.WriteString(fmt.Sprintf("Disable Cache: %t\n", s.DisableCache))
-	_, _ = out.WriteString(fmt.Sprintf("Disable Clustering: %t\n", s.DisableClustering))
-	_, _ = out.WriteString(fmt.Sprintf("Disable Indexing: %t\n", s.DisableIndexing))
-	_, _ = out.WriteString(fmt.Sprintf("Disable Mlock: %t\n", s.DisableMlock))
-	_, _ = out.WriteString(fmt.Sprintf("Disable Performance Standby: %t\n", s.DisablePerformanceStandby))
-	_, _ = out.WriteString(fmt.Sprintf("Disable Printable Check: %t\n", s.DisablePrintableCheck))
-	_, _ = out.WriteString(fmt.Sprintf("Disable Sealwrap: %t\n", s.DisableSealwrap))
-	_, _ = out.WriteString(fmt.Sprintf("Enable UI: %t\n", s.EnableUI))
+	_, _ = fmt.Fprintf(out, "API Addr: %s\n", s.APIAddr)
+	_, _ = fmt.Fprintf(out, "Cache Size: %s\n", s.CacheSize)
+	_, _ = fmt.Fprintf(out, "Cluster Addr: %s\n", s.ClusterAddr)
+	_, _ = fmt.Fprintf(out, "Cluster Cipher Suites: %s\n", s.ClusterCipherSuites)
+	_, _ = fmt.Fprintf(out, "Cluster Name: %s\n", s.ClusterName)
+	_, _ = fmt.Fprintf(out, "Default Lease TTL: %s\n", s.DefaultLeaseTTL)
+	_, _ = fmt.Fprintf(out, "Default Max Request Duration: %s\n", s.DefaultMaxRequestDuration)
+	_, _ = fmt.Fprintf(out, "Disable Cache: %t\n", s.DisableCache)
+	_, _ = fmt.Fprintf(out, "Disable Clustering: %t\n", s.DisableClustering)
+	_, _ = fmt.Fprintf(out, "Disable Indexing: %t\n", s.DisableIndexing)
+	_, _ = fmt.Fprintf(out, "Disable Mlock: %t\n", s.DisableMlock)
+	_, _ = fmt.Fprintf(out, "Disable Performance Standby: %t\n", s.DisablePerformanceStandby)
+	_, _ = fmt.Fprintf(out, "Disable Printable Check: %t\n", s.DisablePrintableCheck)
+	_, _ = fmt.Fprintf(out, "Disable Sealwrap: %t\n", s.DisableSealwrap)
+	_, _ = fmt.Fprintf(out, "Enable UI: %t\n", s.EnableUI)
 	for i := range s.Listeners {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Listeners"))
+			_, _ = fmt.Fprintln(out, "Listeners")
 		}
 
 		if s.Listeners[i] == nil {
 			continue
 		}
 
-		_, _ = out.WriteString(fmt.Sprintf("  Type: %s\n", s.Listeners[i].Type))
+		_, _ = fmt.Fprintf(out, "  Type: %s\n", s.Listeners[i].Type)
 		if s.Listeners[i].Config != nil {
-			_, _ = out.WriteString(fmt.Sprintf("  Address: %s\n", s.Listeners[i].Config.Address))
-			_, _ = out.WriteString(fmt.Sprintf("  TLS Disable: %s\n", s.Listeners[i].Config.TLSDisable))
+			_, _ = fmt.Fprintf(out, "  Address: %s\n", s.Listeners[i].Config.Address)
+			_, _ = fmt.Fprintf(out, "  TLS Disable: %s\n", s.Listeners[i].Config.TLSDisable)
 		}
 	}
-	_, _ = out.WriteString(fmt.Sprintf("Log Format: %s\n", s.LogFormat))
-	_, _ = out.WriteString(fmt.Sprintf("Log Level: %s\n", s.LogLevel))
-	_, _ = out.WriteString(fmt.Sprintf("Max Lease TTL: %s\n", s.MaxLeaseTTL))
-	_, _ = out.WriteString(fmt.Sprintf("PID File: %s\n", s.PIDFile))
-	_, _ = out.WriteString(fmt.Sprintf("Plugin Directory: %s\n", s.PluginDirectory))
-	_, _ = out.WriteString(fmt.Sprintf("Raw Storage Endpoint: %t\n", s.RawStorageEndpoint))
+	_, _ = fmt.Fprintf(out, "Log Format: %s\n", s.LogFormat)
+	_, _ = fmt.Fprintf(out, "Log Level: %s\n", s.LogLevel)
+	_, _ = fmt.Fprintf(out, "Max Lease TTL: %s\n", s.MaxLeaseTTL)
+	_, _ = fmt.Fprintf(out, "PID File: %s\n", s.PIDFile)
+	_, _ = fmt.Fprintf(out, "Plugin Directory: %s\n", s.PluginDirectory)
+	_, _ = fmt.Fprintf(out, "Raw Storage Endpoint: %t\n", s.RawStorageEndpoint)
 	for i := range s.Seals {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Seals"))
+			_, _ = fmt.Fprintln(out, "Seals")
 		}
 
 		if s.Seals[i] == nil {
@@ -198,15 +198,15 @@ func (s *ConfigStateSanitizedResponseData) String() string {
 		}
 
 		if s.Seals[i] != nil {
-			_, _ = out.WriteString(fmt.Sprintf(" Disabled: %t\n", s.Seals[i].Disabled))
-			_, _ = out.WriteString(fmt.Sprintf("  Type: %s\n", s.Seals[i].Type))
+			_, _ = fmt.Fprintf(out, " Disabled: %t\n", s.Seals[i].Disabled)
+			_, _ = fmt.Fprintf(out, "  Type: %s\n", s.Seals[i].Type)
 		}
 	}
-	_, _ = out.WriteString(fmt.Sprintln("Storage"))
-	_, _ = out.WriteString(fmt.Sprintf("  Cluster Addr: %s\n", s.Storage.ClusterAddr))
-	_, _ = out.WriteString(fmt.Sprintf("  Disable Clustering: %t\n", s.Storage.DisableClustering))
-	_, _ = out.WriteString(fmt.Sprintf("  Redirect Addr: %s\n", s.Storage.RedirectAddr))
-	_, _ = out.WriteString(fmt.Sprintf("  Type: %s\n", s.Storage.Type))
+	_, _ = fmt.Fprintln(out, "Storage")
+	_, _ = fmt.Fprintf(out, "  Cluster Addr: %s\n", s.Storage.ClusterAddr)
+	_, _ = fmt.Fprintf(out, "  Disable Clustering: %t\n", s.Storage.DisableClustering)
+	_, _ = fmt.Fprintf(out, "  Redirect Addr: %s\n", s.Storage.RedirectAddr)
+	_, _ = fmt.Fprintf(out, "  Type: %s\n", s.Storage.Type)
 
 	return out.String()
 }

--- a/internal/remoteflight/vault/config_state_test.go
+++ b/internal/remoteflight/vault/config_state_test.go
@@ -46,5 +46,5 @@ func TestConfigStateSanitizedDeserialize(t *testing.T) {
 	body := testReadSupport(t, "config-sanitized.json")
 	require.NoError(t, json.Unmarshal(body, got))
 
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }

--- a/internal/remoteflight/vault/ha_status.go
+++ b/internal/remoteflight/vault/ha_status.go
@@ -67,7 +67,7 @@ func GetHAStatus(ctx context.Context, tr it.Transport, req *CLIRequest) (*HAStat
 			command.WithEnvVar("VAULT_TOKEN", req.Token),
 		))
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 		if stderr != "" {
 			err = errors.Join(err, fmt.Errorf("unexpected write to stderr: %s", stderr))
@@ -118,20 +118,20 @@ func (s *HAStatusNode) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintln("Node"))
-	_, _ = out.WriteString(fmt.Sprintf("  Active Node: %t\n", s.ActiveNode))
-	_, _ = out.WriteString(fmt.Sprintf("  API Address: %s\n", s.APIAddress))
-	_, _ = out.WriteString(fmt.Sprintf("  Cluster Address: %s\n", s.ClusterAddress))
-	_, _ = out.WriteString(fmt.Sprintf("  Hostname: %s\n", s.Hostname))
+	_, _ = fmt.Fprintln(out, "Node")
+	_, _ = fmt.Fprintf(out, "  Active Node: %t\n", s.ActiveNode)
+	_, _ = fmt.Fprintf(out, "  API Address: %s\n", s.APIAddress)
+	_, _ = fmt.Fprintf(out, "  Cluster Address: %s\n", s.ClusterAddress)
+	_, _ = fmt.Fprintf(out, "  Hostname: %s\n", s.Hostname)
 
 	if s.LastEcho != "" {
-		_, _ = out.WriteString(fmt.Sprintf("  Last Echo: %s\n", s.LastEcho))
+		_, _ = fmt.Fprintf(out, "  Last Echo: %s\n", s.LastEcho)
 	}
 	if s.RedundancyZone != "" {
-		_, _ = out.WriteString(fmt.Sprintf("  Redundancy Zone: %s\n", s.RedundancyZone))
+		_, _ = fmt.Fprintf(out, "  Redundancy Zone: %s\n", s.RedundancyZone)
 	}
 	if s.UpgradeVersion != "" {
-		_, _ = out.WriteString(fmt.Sprintf("  Upgrade Version: %s\n", s.UpgradeVersion))
+		_, _ = fmt.Fprintf(out, "  Upgrade Version: %s\n", s.UpgradeVersion)
 	}
 
 	return out.String()

--- a/internal/remoteflight/vault/ha_status_test.go
+++ b/internal/remoteflight/vault/ha_status_test.go
@@ -50,5 +50,5 @@ func TestHAStatusDeserialize(t *testing.T) {
 	body := testReadSupport(t, "ha-status.json")
 	require.NoError(t, json.Unmarshal(body, got))
 
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }

--- a/internal/remoteflight/vault/health.go
+++ b/internal/remoteflight/vault/health.go
@@ -192,7 +192,7 @@ func GetHealth(ctx context.Context, tr it.Transport, req *HealthRequest) (*Healt
 			// from the exit code. If it isn't valid then return an error.
 			code, err1 := healthStatusFromError(err1)
 			if err1 != nil {
-				err = errors.Join(err, err1)
+				err = err1
 			} else {
 				res.HealthStatus = code
 			}
@@ -285,18 +285,18 @@ func (r *HealthResponse) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintf("Status: %s\n", r.Status()))
-	_, _ = out.WriteString(fmt.Sprintf("Cluster ID: %s\n", r.ClusterID))
-	_, _ = out.WriteString(fmt.Sprintf("Cluster Name: %s\n", r.ClusterID))
-	_, _ = out.WriteString(fmt.Sprintf("Initialized: %t\n", r.Initialized))
-	_, _ = out.WriteString(fmt.Sprintf("Sealed: %t\n", r.Sealed))
-	_, _ = out.WriteString(fmt.Sprintf("Standby: %t\n", r.Standby))
-	_, _ = out.WriteString(fmt.Sprintf("Version: %t\n", r.Standby))
-	_, _ = out.WriteString(fmt.Sprintf("Last WAL: %d\n", r.LastWAL))
-	_, _ = out.WriteString(fmt.Sprintf("Performance Standby: %t\n", r.PerformanceStandby))
-	_, _ = out.WriteString(fmt.Sprintf("Replication DR Mode: %s\n", r.ReplicationDRMode))
-	_, _ = out.WriteString(fmt.Sprintf("Replication Performance Mode: %s\n", r.ReplicationPerformanceMode))
-	_, _ = out.WriteString(fmt.Sprintf("Server Time UTC: %d\n", r.ServerTimeUTC))
+	_, _ = fmt.Fprintf(out, "Status: %s\n", r.Status())
+	_, _ = fmt.Fprintf(out, "Cluster ID: %s\n", r.ClusterID)
+	_, _ = fmt.Fprintf(out, "Cluster Name: %s\n", r.ClusterID)
+	_, _ = fmt.Fprintf(out, "Initialized: %t\n", r.Initialized)
+	_, _ = fmt.Fprintf(out, "Sealed: %t\n", r.Sealed)
+	_, _ = fmt.Fprintf(out, "Standby: %t\n", r.Standby)
+	_, _ = fmt.Fprintf(out, "Version: %t\n", r.Standby)
+	_, _ = fmt.Fprintf(out, "Last WAL: %d\n", r.LastWAL)
+	_, _ = fmt.Fprintf(out, "Performance Standby: %t\n", r.PerformanceStandby)
+	_, _ = fmt.Fprintf(out, "Replication DR Mode: %s\n", r.ReplicationDRMode)
+	_, _ = fmt.Fprintf(out, "Replication Performance Mode: %s\n", r.ReplicationPerformanceMode)
+	_, _ = fmt.Fprintf(out, "Server Time UTC: %d\n", r.ServerTimeUTC)
 	if r.License != nil {
 		_, _ = out.WriteString("License:\n" + istrings.Indent("  ", r.License.String()))
 	}

--- a/internal/remoteflight/vault/health_test.go
+++ b/internal/remoteflight/vault/health_test.go
@@ -26,5 +26,5 @@ func TestHealthDeserialize(t *testing.T) {
 	got := NewHealthResponse()
 	body := testReadSupport(t, "health.json")
 	require.NoError(t, json.Unmarshal(body, got))
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }

--- a/internal/remoteflight/vault/host_info.go
+++ b/internal/remoteflight/vault/host_info.go
@@ -71,7 +71,7 @@ func GetHostInfo(ctx context.Context, tr it.Transport, req *CLIRequest) (*HostIn
 			command.WithEnvVar("VAULT_TOKEN", req.Token),
 		))
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 		if stderr != "" {
 			err = errors.Join(err, fmt.Errorf("unexpected write to STDERR: %s", stderr))
@@ -117,22 +117,22 @@ func (s *HostInfoHost) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintf("Boot Time: %s\n", s.BootTime))
-	_, _ = out.WriteString(fmt.Sprintf("Host ID: %s\n", s.HostID))
-	_, _ = out.WriteString(fmt.Sprintf("Hostname: %s\n", s.Hostname))
-	_, _ = out.WriteString(fmt.Sprintf("Kernel Arch: %s\n", s.KernelArch))
-	_, _ = out.WriteString(fmt.Sprintf("Kernel Version: %s\n", s.KernelVersion))
-	_, _ = out.WriteString(fmt.Sprintf("OS: %s\n", s.OS))
-	_, _ = out.WriteString(fmt.Sprintf("Platform: %s\n", s.Platform))
-	_, _ = out.WriteString(fmt.Sprintf("Platform Family: %s\n", s.PlatformFamily))
-	_, _ = out.WriteString(fmt.Sprintf("Procs: %s\n", s.Procs))
-	_, _ = out.WriteString(fmt.Sprintf("Uptime: %s\n", s.Uptime))
+	_, _ = fmt.Fprintf(out, "Boot Time: %s\n", s.BootTime)
+	_, _ = fmt.Fprintf(out, "Host ID: %s\n", s.HostID)
+	_, _ = fmt.Fprintf(out, "Hostname: %s\n", s.Hostname)
+	_, _ = fmt.Fprintf(out, "Kernel Arch: %s\n", s.KernelArch)
+	_, _ = fmt.Fprintf(out, "Kernel Version: %s\n", s.KernelVersion)
+	_, _ = fmt.Fprintf(out, "OS: %s\n", s.OS)
+	_, _ = fmt.Fprintf(out, "Platform: %s\n", s.Platform)
+	_, _ = fmt.Fprintf(out, "Platform Family: %s\n", s.PlatformFamily)
+	_, _ = fmt.Fprintf(out, "Procs: %s\n", s.Procs)
+	_, _ = fmt.Fprintf(out, "Uptime: %s\n", s.Uptime)
 
 	if s.VirtualizationRole != "" {
-		_, _ = out.WriteString(fmt.Sprintf("Virtualization Role: %s\n", s.VirtualizationRole))
+		_, _ = fmt.Fprintf(out, "Virtualization Role: %s\n", s.VirtualizationRole)
 	}
 	if s.VirtualizationSystem != "" {
-		_, _ = out.WriteString(fmt.Sprintf("Virtualization System: %s\n", s.VirtualizationSystem))
+		_, _ = fmt.Fprintf(out, "Virtualization System: %s\n", s.VirtualizationSystem)
 	}
 
 	return out.String()

--- a/internal/remoteflight/vault/host_info_test.go
+++ b/internal/remoteflight/vault/host_info_test.go
@@ -30,5 +30,5 @@ func TestHostInfoDeserialize(t *testing.T) {
 	got := NewHostInfoResponse()
 	body := testReadSupport(t, "host-info.json")
 	require.NoError(t, json.Unmarshal(body, got))
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }

--- a/internal/remoteflight/vault/init.go
+++ b/internal/remoteflight/vault/init.go
@@ -202,34 +202,34 @@ func (r *InitRequest) String() string {
 	cmd := &strings.Builder{}
 	cmd.WriteString(r.BinPath + " operator init -format=json")
 	if r.KeyShares != -1 {
-		cmd.WriteString(fmt.Sprintf(" -key-shares=%d", r.KeyShares))
+		fmt.Fprintf(cmd, " -key-shares=%d", r.KeyShares)
 	}
 	if r.KeyThreshold != -1 {
-		cmd.WriteString(fmt.Sprintf(" -key-threshold=%d", r.KeyThreshold))
+		fmt.Fprintf(cmd, " -key-threshold=%d", r.KeyThreshold)
 	}
 	if len(r.PGPKeys) > 0 {
-		cmd.WriteString(fmt.Sprintf(" -pgp-keys='%s'", strings.Join(r.PGPKeys, ",")))
+		fmt.Fprintf(cmd, " -pgp-keys='%s'", strings.Join(r.PGPKeys, ","))
 	}
 	if r.RecoveryShares != -1 {
-		cmd.WriteString(fmt.Sprintf(" -recovery-shares=%d", r.RecoveryShares))
+		fmt.Fprintf(cmd, " -recovery-shares=%d", r.RecoveryShares)
 	}
 	if r.RecoveryThreshold != -1 {
-		cmd.WriteString(fmt.Sprintf(" -recovery-threshold=%d", r.RecoveryThreshold))
+		fmt.Fprintf(cmd, " -recovery-threshold=%d", r.RecoveryThreshold)
 	}
 	if len(r.RecoveryPGPKeys) > 0 {
-		cmd.WriteString(fmt.Sprintf(" -recovery-pgp-keys='%s'", strings.Join(r.RecoveryPGPKeys, ",")))
+		fmt.Fprintf(cmd, " -recovery-pgp-keys='%s'", strings.Join(r.RecoveryPGPKeys, ","))
 	}
 	if r.RootTokenPGPKey != "" {
-		cmd.WriteString(fmt.Sprintf(" -root-token-pgp-key='%s'", r.RootTokenPGPKey))
+		fmt.Fprintf(cmd, " -root-token-pgp-key='%s'", r.RootTokenPGPKey)
 	}
 	if r.ConsulAuto {
 		cmd.WriteString(" -consul-auto=true")
 	}
 	if r.ConsulService != "" {
-		cmd.WriteString(fmt.Sprintf(" -consul-service='%s'", r.ConsulService))
+		fmt.Fprintf(cmd, " -consul-service='%s'", r.ConsulService)
 	}
 	if r.StoredShares != -1 {
-		cmd.WriteString(fmt.Sprintf(" -stored-shares=%d", r.StoredShares))
+		fmt.Fprintf(cmd, " -stored-shares=%d", r.StoredShares)
 	}
 
 	return cmd.String()

--- a/internal/remoteflight/vault/raft.go
+++ b/internal/remoteflight/vault/raft.go
@@ -179,7 +179,7 @@ func GetRaftConfiguration(ctx context.Context, tr it.Transport, req *CLIRequest)
 			command.WithEnvVar("VAULT_TOKEN", req.Token),
 		))
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 		if stderr != "" {
 			err = errors.Join(err, fmt.Errorf("unexpected write to STDERR: %s", stderr))
@@ -230,7 +230,7 @@ func GetRaftAutopilotConfiguration(ctx context.Context, tr it.Transport, req *CL
 			command.WithEnvVar("VAULT_TOKEN", req.Token),
 		))
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 		if stderr != "" {
 			err = errors.Join(err, fmt.Errorf("unexpected write to STDERR: %s", stderr))
@@ -281,7 +281,7 @@ func GetRaftAutopilotState(ctx context.Context, tr it.Transport, req *CLIRequest
 			command.WithEnvVar("VAULT_TOKEN", req.Token),
 		))
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 		if stderr != "" {
 			err = errors.Join(err, fmt.Errorf("unexpected write to STDERR: %s", stderr))
@@ -327,13 +327,13 @@ func (s *RaftConfigurationDataConfig) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintf("Index: %s\n", s.Index))
+	_, _ = fmt.Fprintf(out, "Index: %s\n", s.Index)
 
 	if len(s.Servers) < 1 {
 		return out.String()
 	}
 
-	_, _ = out.WriteString(fmt.Sprintln("Servers:"))
+	_, _ = fmt.Fprintln(out, "Servers:")
 	for i := range s.Servers {
 		_, _ = out.WriteString(istrings.Indent("  ", s.Servers[i].String()))
 	}
@@ -348,12 +348,12 @@ func (s *RaftConfigurationServer) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintln("Server"))
-	_, _ = out.WriteString(fmt.Sprintf("  Address: %s\n", s.Address))
-	_, _ = out.WriteString(fmt.Sprintf("  Leader: %t\n", s.Leader))
-	_, _ = out.WriteString(fmt.Sprintf("  Node ID: %s\n", s.NodeID))
-	_, _ = out.WriteString(fmt.Sprintf("  Protocol Version: %s\n", s.ProtocolVersion))
-	_, _ = out.WriteString(fmt.Sprintf("  Voter: %t\n", s.Voter))
+	_, _ = fmt.Fprintln(out, "Server")
+	_, _ = fmt.Fprintf(out, "  Address: %s\n", s.Address)
+	_, _ = fmt.Fprintf(out, "  Leader: %t\n", s.Leader)
+	_, _ = fmt.Fprintf(out, "  Node ID: %s\n", s.NodeID)
+	_, _ = fmt.Fprintf(out, "  Protocol Version: %s\n", s.ProtocolVersion)
+	_, _ = fmt.Fprintf(out, "  Voter: %t\n", s.Voter)
 
 	return out.String()
 }
@@ -374,13 +374,13 @@ func (s *RaftAutopilotConfigurationData) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintf("Cleanup Dead Servers: %t\n", s.CleanupDeadServers))
-	_, _ = out.WriteString(fmt.Sprintf("Dead Server Last Contact Threshold: %s\n", s.DeadServerLastContactThreshold))
-	_, _ = out.WriteString(fmt.Sprintf("Last Contact Threshold: %s\n", s.LastContactThreshold))
-	_, _ = out.WriteString(fmt.Sprintf("Max Trailing Logs: %s\n", s.MaxTrailingLogs))
-	_, _ = out.WriteString(fmt.Sprintf("Min Quorum: %s\n", s.MinQuorum))
-	_, _ = out.WriteString(fmt.Sprintf("Server Stabilization Time: %s\n", s.ServerStabilizationTime))
-	_, _ = out.WriteString(fmt.Sprintf("Disable Upgrade Migration: %t\n", s.DisableUpgradeMigration))
+	_, _ = fmt.Fprintf(out, "Cleanup Dead Servers: %t\n", s.CleanupDeadServers)
+	_, _ = fmt.Fprintf(out, "Dead Server Last Contact Threshold: %s\n", s.DeadServerLastContactThreshold)
+	_, _ = fmt.Fprintf(out, "Last Contact Threshold: %s\n", s.LastContactThreshold)
+	_, _ = fmt.Fprintf(out, "Max Trailing Logs: %s\n", s.MaxTrailingLogs)
+	_, _ = fmt.Fprintf(out, "Min Quorum: %s\n", s.MinQuorum)
+	_, _ = fmt.Fprintf(out, "Server Stabilization Time: %s\n", s.ServerStabilizationTime)
+	_, _ = fmt.Fprintf(out, "Disable Upgrade Migration: %t\n", s.DisableUpgradeMigration)
 
 	return out.String()
 }
@@ -401,44 +401,44 @@ func (r *RaftAutopilotStateResponseData) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintf("Healthy: %t\n", r.Healthy))
-	_, _ = out.WriteString(fmt.Sprintf("Failure Tolerance: %s\n", r.FailureTolerance))
-	_, _ = out.WriteString(fmt.Sprintf("Leader: %s\n", r.Leader))
-	_, _ = out.WriteString(fmt.Sprintf("Optimistic Failure Tolerance: %s\n", r.OptimisticFailureTolerance))
+	_, _ = fmt.Fprintf(out, "Healthy: %t\n", r.Healthy)
+	_, _ = fmt.Fprintf(out, "Failure Tolerance: %s\n", r.FailureTolerance)
+	_, _ = fmt.Fprintf(out, "Leader: %s\n", r.Leader)
+	_, _ = fmt.Fprintf(out, "Optimistic Failure Tolerance: %s\n", r.OptimisticFailureTolerance)
 
 	if len(r.RedundancyZones) > 0 {
-		_, _ = out.WriteString(fmt.Sprintln("Redundancy Zones:"))
+		_, _ = fmt.Fprintln(out, "Redundancy Zones:")
 		for name, val := range r.RedundancyZones {
-			_, _ = out.WriteString(fmt.Sprintf("  %s\n", name))
+			_, _ = fmt.Fprintf(out, "  %s\n", name)
 			_, _ = out.WriteString(istrings.Indent("  ", val.String()))
 		}
 	}
 
 	if len(r.Servers) > 0 {
-		_, _ = out.WriteString(fmt.Sprintln("Servers:"))
+		_, _ = fmt.Fprintln(out, "Servers:")
 		for name, val := range r.Servers {
-			_, _ = out.WriteString(fmt.Sprintf("  %s\n", name))
+			_, _ = fmt.Fprintf(out, "  %s\n", name)
 			_, _ = out.WriteString(istrings.Indent("  ", val.String()))
 		}
 	}
 
 	if r.UpgradeInfo != nil && r.UpgradeInfo.Status != "" {
-		_, _ = out.WriteString(fmt.Sprintln("Upgrade Info:"))
+		_, _ = fmt.Fprintln(out, "Upgrade Info:")
 		_, _ = out.WriteString(istrings.Indent("  ", r.UpgradeInfo.String()))
 	}
 
 	for i := range r.Voters {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Voters"))
+			_, _ = fmt.Fprintln(out, "Voters")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.Voters[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.Voters[i])
 	}
 
 	for i := range r.NonVoters {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Nonvoters"))
+			_, _ = fmt.Fprintln(out, "Nonvoters")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.NonVoters[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.NonVoters[i])
 	}
 
 	return out.String()
@@ -454,19 +454,19 @@ func (r *RaftAutopilotStateRedundancyZone) String() string {
 
 	for i := range r.Servers {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Servers"))
+			_, _ = fmt.Fprintln(out, "Servers")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.Servers[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.Servers[i])
 	}
 
 	for i := range r.Voters {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Voters"))
+			_, _ = fmt.Fprintln(out, "Voters")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.Voters[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.Voters[i])
 	}
 
-	_, _ = out.WriteString(fmt.Sprintln(r.FailureTolerance))
+	_, _ = fmt.Fprintln(out, r.FailureTolerance)
 
 	return out.String()
 }
@@ -478,16 +478,16 @@ func (r *RaftAutopilotStateServer) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintf("ID: %s\n", r.ID))
-	_, _ = out.WriteString(fmt.Sprintf("Name: %s\n", r.Name))
-	_, _ = out.WriteString(fmt.Sprintf("Address: %s\n", r.Address))
-	_, _ = out.WriteString(fmt.Sprintf("Node Status: %s\n", r.NodeStatus))
-	_, _ = out.WriteString(fmt.Sprintf("Last Contact: %s\n", r.LastContact))
-	_, _ = out.WriteString(fmt.Sprintf("Last Term: %s\n", r.LastTerm))
-	_, _ = out.WriteString(fmt.Sprintf("Healthy: %t\n", r.Healthy))
-	_, _ = out.WriteString(fmt.Sprintf("Stable Since: %s\n", r.StableSince))
-	_, _ = out.WriteString(fmt.Sprintf("Status: %s\n", r.Status))
-	_, _ = out.WriteString(fmt.Sprintf("Meta: %s\n", r.Meta))
+	_, _ = fmt.Fprintf(out, "ID: %s\n", r.ID)
+	_, _ = fmt.Fprintf(out, "Name: %s\n", r.Name)
+	_, _ = fmt.Fprintf(out, "Address: %s\n", r.Address)
+	_, _ = fmt.Fprintf(out, "Node Status: %s\n", r.NodeStatus)
+	_, _ = fmt.Fprintf(out, "Last Contact: %s\n", r.LastContact)
+	_, _ = fmt.Fprintf(out, "Last Term: %s\n", r.LastTerm)
+	_, _ = fmt.Fprintf(out, "Healthy: %t\n", r.Healthy)
+	_, _ = fmt.Fprintf(out, "Stable Since: %s\n", r.StableSince)
+	_, _ = fmt.Fprintf(out, "Status: %s\n", r.Status)
+	_, _ = fmt.Fprintf(out, "Meta: %s\n", r.Meta)
 
 	return out.String()
 }
@@ -501,34 +501,34 @@ func (r *RaftAutopilotStateUpgradeInfo) String() string {
 
 	for i := range r.OtherVersionNonVoters {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Other Version Nonvoters"))
+			_, _ = fmt.Fprintln(out, "Other Version Nonvoters")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.OtherVersionNonVoters[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.OtherVersionNonVoters[i])
 	}
 
 	for i := range r.OtherVersionVoters {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Other Version Voters"))
+			_, _ = fmt.Fprintln(out, "Other Version Voters")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.OtherVersionVoters[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.OtherVersionVoters[i])
 	}
 
 	if len(r.RedundancyZones) > 0 {
-		_, _ = out.WriteString(fmt.Sprintln("Redundancy Zones:"))
+		_, _ = fmt.Fprintln(out, "Redundancy Zones:")
 	}
 	for name, val := range r.RedundancyZones {
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", name))
+		_, _ = fmt.Fprintf(out, "  %s\n", name)
 		_, _ = out.WriteString(istrings.Indent("  ", val.String()))
 	}
 
-	_, _ = out.WriteString(fmt.Sprintf("Status: %s\n", r.Status))
-	_, _ = out.WriteString(fmt.Sprintf("Target Version: %s\n", r.TargetVersion))
+	_, _ = fmt.Fprintf(out, "Status: %s\n", r.Status)
+	_, _ = fmt.Fprintf(out, "Target Version: %s\n", r.TargetVersion)
 
 	for i := range r.TargetVersionNonVoters {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Target Version Nonvoters"))
+			_, _ = fmt.Fprintln(out, "Target Version Nonvoters")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.TargetVersionNonVoters[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.TargetVersionNonVoters[i])
 	}
 
 	return out.String()
@@ -543,23 +543,23 @@ func (r *RaftAutopilotStateUpgradeInfoRedundancyZone) String() string {
 
 	for i := range r.TargetVersionNonVoters {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Target Version Nonvoters"))
+			_, _ = fmt.Fprintln(out, "Target Version Nonvoters")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.TargetVersionNonVoters[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.TargetVersionNonVoters[i])
 	}
 
 	for i := range r.OtherVersionVoters {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Other Version Voters"))
+			_, _ = fmt.Fprintln(out, "Other Version Voters")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.OtherVersionVoters[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.OtherVersionVoters[i])
 	}
 
 	for i := range r.OtherVersionNonVoters {
 		if i == 0 {
-			_, _ = out.WriteString(fmt.Sprintln("Other Version Nonvoters"))
+			_, _ = fmt.Fprintln(out, "Other Version Nonvoters")
 		}
-		_, _ = out.WriteString(fmt.Sprintf("  %s\n", r.OtherVersionNonVoters[i]))
+		_, _ = fmt.Fprintf(out, "  %s\n", r.OtherVersionNonVoters[i])
 	}
 
 	return out.String()

--- a/internal/remoteflight/vault/raft_test.go
+++ b/internal/remoteflight/vault/raft_test.go
@@ -42,7 +42,7 @@ func TestRaftConfigurationDeserialize(t *testing.T) {
 	body := testReadSupport(t, "storage-raft-configuration.json")
 	require.NoError(t, json.Unmarshal(body, got))
 
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }
 
 func TestRaftAutopilotConfigurationDeserialize(t *testing.T) {
@@ -58,7 +58,7 @@ func TestRaftAutopilotConfigurationDeserialize(t *testing.T) {
 	body := testReadSupport(t, "storage-raft-autopilot-configuration.json")
 	require.NoError(t, json.Unmarshal(body, got))
 
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }
 
 func TestRaftAutopilotStateDeserialize(t *testing.T) {
@@ -115,5 +115,5 @@ func TestRaftAutopilotStateDeserialize(t *testing.T) {
 	body := testReadSupport(t, "storage-raft-autopilot-state.json")
 	require.NoError(t, json.Unmarshal(body, got))
 
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }

--- a/internal/remoteflight/vault/replication.go
+++ b/internal/remoteflight/vault/replication.go
@@ -70,7 +70,7 @@ func NewReplicationRequest(opts ...ReplicationRequestOpt) *ReplicationRequest {
 // WithReplicationRequestBinPath sets the vault binary path.
 func WithReplicationRequestBinPath(path string) ReplicationRequestOpt {
 	return func(u *ReplicationRequest) *ReplicationRequest {
-		u.CLIRequest.BinPath = path
+		u.BinPath = path
 		return u
 	}
 }
@@ -78,7 +78,7 @@ func WithReplicationRequestBinPath(path string) ReplicationRequestOpt {
 // WithReplicationRequestVaultAddr sets the vault address.
 func WithReplicationRequestVaultAddr(addr string) ReplicationRequestOpt {
 	return func(u *ReplicationRequest) *ReplicationRequest {
-		u.CLIRequest.VaultAddr = addr
+		u.VaultAddr = addr
 		return u
 	}
 }
@@ -108,7 +108,7 @@ func GetReplicationStatus(ctx context.Context, tr it.Transport, req *Replication
 			command.WithEnvVar("VAULT_ADDR", req.VaultAddr),
 		))
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 		if stderr != "" {
 			err = errors.Join(err, fmt.Errorf("unexpected write to STDERR: %s", stderr))
@@ -173,18 +173,18 @@ func (s *ReplicationDataStatus) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintf("Cluster ID: %s\n", s.ClusterID))
+	_, _ = fmt.Fprintf(out, "Cluster ID: %s\n", s.ClusterID)
 	if len(s.KnownSecondaries) > 0 {
-		_, _ = out.WriteString(fmt.Sprintln("Known Secondaries"))
+		_, _ = fmt.Fprintln(out, "Known Secondaries")
 		for i := range s.KnownSecondaries {
-			_, _ = out.WriteString(fmt.Sprintf("  %s\n", s.KnownSecondaries[i]))
+			_, _ = fmt.Fprintf(out, "  %s\n", s.KnownSecondaries[i])
 		}
 	}
-	_, _ = out.WriteString(fmt.Sprintf("Last WAL: %s\n", s.LastWAL))
-	_, _ = out.WriteString(fmt.Sprintf("Merkle Root: %s\n", s.MerkleRoot))
-	_, _ = out.WriteString(fmt.Sprintf("Mode: %s\n", s.Mode))
+	_, _ = fmt.Fprintf(out, "Last WAL: %s\n", s.LastWAL)
+	_, _ = fmt.Fprintf(out, "Merkle Root: %s\n", s.MerkleRoot)
+	_, _ = fmt.Fprintf(out, "Mode: %s\n", s.Mode)
 	if len(s.Secondaries) > 0 {
-		_, _ = out.WriteString(fmt.Sprintln("Secondaries"))
+		_, _ = fmt.Fprintln(out, "Secondaries")
 		for i := range s.Secondaries {
 			_, _ = out.WriteString(istrings.Indent("  ", s.Secondaries[i].String()))
 		}
@@ -200,12 +200,12 @@ func (s *ReplicationSecondary) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintln("Secondary"))
-	_, _ = out.WriteString(fmt.Sprintf("  API Address: %s\n", s.APIAddress))
-	_, _ = out.WriteString(fmt.Sprintf("  Cluster Address: %s\n", s.ClusterAddress))
-	_, _ = out.WriteString(fmt.Sprintf("  Connection Status: %s\n", s.ConnectionStatus))
-	_, _ = out.WriteString(fmt.Sprintf("  Last Heartbeat: %s\n", s.LastHeartbeat))
-	_, _ = out.WriteString(fmt.Sprintf("  Node ID: %s\n", s.NodeID))
+	_, _ = fmt.Fprintln(out, "Secondary")
+	_, _ = fmt.Fprintf(out, "  API Address: %s\n", s.APIAddress)
+	_, _ = fmt.Fprintf(out, "  Cluster Address: %s\n", s.ClusterAddress)
+	_, _ = fmt.Fprintf(out, "  Connection Status: %s\n", s.ConnectionStatus)
+	_, _ = fmt.Fprintf(out, "  Last Heartbeat: %s\n", s.LastHeartbeat)
+	_, _ = fmt.Fprintf(out, "  Node ID: %s\n", s.NodeID)
 
 	return out.String()
 }

--- a/internal/remoteflight/vault/replication_test.go
+++ b/internal/remoteflight/vault/replication_test.go
@@ -35,5 +35,5 @@ func TestReplicationStatusDeserialize(t *testing.T) {
 	got := NewReplicationResponse()
 	body := testReadSupport(t, "replication-status.json")
 	require.NoError(t, json.Unmarshal(body, got))
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }

--- a/internal/remoteflight/vault/seal_status.go
+++ b/internal/remoteflight/vault/seal_status.go
@@ -105,7 +105,7 @@ func GetSealStatus(ctx context.Context, tr it.Transport, req *SealStatusRequest)
 	if err == nil {
 		stdout, stderr, err1 := tr.Run(ctx, command.New(req.String()))
 		if err1 != nil {
-			err = errors.Join(err, err1)
+			err = err1
 		}
 		if stderr != "" {
 			err = errors.Join(err, fmt.Errorf("unexpected write to STDERR: %s", stderr))
@@ -175,20 +175,20 @@ func (s *SealStatusResponseData) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintf("Build Date: %s\n", s.BuildDate))
-	_, _ = out.WriteString(fmt.Sprintf("Cluster ID: %s\n", s.ClusterID))
-	_, _ = out.WriteString(fmt.Sprintf("Cluster Name: %s\n", s.ClusterName))
-	_, _ = out.WriteString(fmt.Sprintf("Initialized: %t\n", s.Initialized))
-	_, _ = out.WriteString(fmt.Sprintf("Migration: %t\n", s.Migration))
-	_, _ = out.WriteString(fmt.Sprintf("Number: %s\n", s.Number))
-	_, _ = out.WriteString(fmt.Sprintf("Nonce: %s\n", s.Nonce))
-	_, _ = out.WriteString(fmt.Sprintf("Progress: %s\n", s.Progress))
-	_, _ = out.WriteString(fmt.Sprintf("Recovery Seal: %t\n", s.RecoverySeal))
-	_, _ = out.WriteString(fmt.Sprintf("Sealed: %t\n", s.Sealed))
-	_, _ = out.WriteString(fmt.Sprintf("Storage Type: %s\n", s.StorageType))
-	_, _ = out.WriteString(fmt.Sprintf("Threshold: %s\n", s.Threshold))
-	_, _ = out.WriteString(fmt.Sprintf("Type: %s\n", s.Type))
-	_, _ = out.WriteString(fmt.Sprintf("Version: %s\n", s.Version))
+	_, _ = fmt.Fprintf(out, "Build Date: %s\n", s.BuildDate)
+	_, _ = fmt.Fprintf(out, "Cluster ID: %s\n", s.ClusterID)
+	_, _ = fmt.Fprintf(out, "Cluster Name: %s\n", s.ClusterName)
+	_, _ = fmt.Fprintf(out, "Initialized: %t\n", s.Initialized)
+	_, _ = fmt.Fprintf(out, "Migration: %t\n", s.Migration)
+	_, _ = fmt.Fprintf(out, "Number: %s\n", s.Number)
+	_, _ = fmt.Fprintf(out, "Nonce: %s\n", s.Nonce)
+	_, _ = fmt.Fprintf(out, "Progress: %s\n", s.Progress)
+	_, _ = fmt.Fprintf(out, "Recovery Seal: %t\n", s.RecoverySeal)
+	_, _ = fmt.Fprintf(out, "Sealed: %t\n", s.Sealed)
+	_, _ = fmt.Fprintf(out, "Storage Type: %s\n", s.StorageType)
+	_, _ = fmt.Fprintf(out, "Threshold: %s\n", s.Threshold)
+	_, _ = fmt.Fprintf(out, "Type: %s\n", s.Type)
+	_, _ = fmt.Fprintf(out, "Version: %s\n", s.Version)
 
 	return out.String()
 }

--- a/internal/remoteflight/vault/seal_status_test.go
+++ b/internal/remoteflight/vault/seal_status_test.go
@@ -29,7 +29,7 @@ func TestSealStatusDeserialize(t *testing.T) {
 	got := NewSealStatusResponse()
 	body := testReadSupport(t, "seal-status.json")
 	require.NoError(t, json.Unmarshal(body, got))
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }
 
 func TestSealStatusDeserializeOldResponseBody(t *testing.T) {
@@ -47,5 +47,5 @@ func TestSealStatusDeserializeOldResponseBody(t *testing.T) {
 	got := NewSealStatusResponse()
 	body := testReadSupport(t, "seal-status-old.json")
 	require.NoError(t, json.Unmarshal(body, got.Data))
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }

--- a/internal/remoteflight/vault/state.go
+++ b/internal/remoteflight/vault/state.go
@@ -93,7 +93,7 @@ func NewStateRequest(opts ...StateRequestOpt) *StateRequest {
 // WithStateRequestBinPath sets the vault binary path.
 func WithStateRequestBinPath(path string) StateRequestOpt {
 	return func(u *StateRequest) *StateRequest {
-		u.CLIRequest.BinPath = path
+		u.BinPath = path
 		return u
 	}
 }
@@ -101,7 +101,7 @@ func WithStateRequestBinPath(path string) StateRequestOpt {
 // WithStateRequestVaultAddr sets the vault address.
 func WithStateRequestVaultAddr(addr string) StateRequestOpt {
 	return func(u *StateRequest) *StateRequest {
-		u.CLIRequest.VaultAddr = addr
+		u.VaultAddr = addr
 		return u
 	}
 }
@@ -109,7 +109,7 @@ func WithStateRequestVaultAddr(addr string) StateRequestOpt {
 // WithStateRequestVaultToken sets the vault token.
 func WithStateRequestVaultToken(token string) StateRequestOpt {
 	return func(u *StateRequest) *StateRequest {
-		u.CLIRequest.Token = token
+		u.Token = token
 		return u
 	}
 }
@@ -191,7 +191,7 @@ func GetState(ctx context.Context, tr it.Transport, req *StateRequest) (*State, 
 			return state, errors.New("getting the kubernetes pods state: type mismatch between transport")
 		}
 
-		req.ListPodsRequest.Namespace = k.Namespace
+		req.Namespace = k.Namespace
 		state.PodList, err = k.Client.ListPods(ctx, req.ListPodsRequest)
 		if err != nil {
 			return state, fmt.Errorf("getting the kubernetes pod information: %w", err)
@@ -280,7 +280,7 @@ func GetState(ctx context.Context, tr it.Transport, req *StateRequest) (*State, 
 	// The following sub-state endpoints require privileged access, which means
 	// that our cluster must be initialized and unsealed and that we have been
 	// configured with a token.
-	if req.CLIRequest.Token == "" {
+	if req.Token == "" {
 		return state, nil
 	}
 
@@ -423,7 +423,7 @@ func (s *State) printStateField(w io.Writer, f fmt.Stringer, fn string) {
 	if fs == "" {
 		return
 	}
-	_, _ = w.Write([]byte(fmt.Sprintf("%s: \n%s\n", fn, istrings.Indent("  ", fs))))
+	_, _ = fmt.Fprintf(w, "%s: \n%s\n", fn, istrings.Indent("  ", fs))
 }
 
 // IsSealed checks whether or not the state is sealed. If we are unable to

--- a/internal/remoteflight/vault/status.go
+++ b/internal/remoteflight/vault/status.go
@@ -158,16 +158,16 @@ func (s *StatusResponse) String() string {
 	}
 
 	out := new(strings.Builder)
-	_, _ = out.WriteString(fmt.Sprintf("Code: %[1]d (%[1]s)\n", s.StatusCode))
+	_, _ = fmt.Fprintf(out, "Code: %[1]d (%[1]s)\n", s.StatusCode)
 	if s.SealType != "" {
-		_, _ = out.WriteString(fmt.Sprintf("Seal Type: %s\n", s.SealType))
+		_, _ = fmt.Fprintf(out, "Seal Type: %s\n", s.SealType)
 	}
-	_, _ = out.WriteString(fmt.Sprintf("Initialized: %t\n", s.Initialized))
-	_, _ = out.WriteString(fmt.Sprintf("Sealed: %t\n", s.Sealed))
+	_, _ = fmt.Fprintf(out, "Initialized: %t\n", s.Initialized)
+	_, _ = fmt.Fprintf(out, "Sealed: %t\n", s.Sealed)
 	if s.Version != "" {
-		_, _ = out.WriteString(fmt.Sprintf("Version: %s\n", s.Version))
+		_, _ = fmt.Fprintf(out, "Version: %s\n", s.Version)
 	}
-	_, _ = out.WriteString(fmt.Sprintf("HA Enabled: %t\n", s.HAEnabled))
+	_, _ = fmt.Fprintf(out, "HA Enabled: %t\n", s.HAEnabled)
 
 	return out.String()
 }

--- a/internal/remoteflight/vault/status_test.go
+++ b/internal/remoteflight/vault/status_test.go
@@ -21,5 +21,5 @@ func TestStatusDeserialize(t *testing.T) {
 	got := NewStatusResponse()
 	body := testReadSupport(t, "status.json")
 	require.NoError(t, json.Unmarshal(body, got))
-	require.EqualValues(t, expected, got)
+	require.Equal(t, expected, got)
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -51,7 +51,7 @@ func Retry(ctx context.Context, req Retryable) (any, error) {
 			return res, nil
 		} else {
 			if attempts > 1 {
-				//nolint:stylecheck
+				//nolint:all
 				//lint:ignore ST1005 it's okay to add a newline here for readability
 				err = errors.Join(err, fmt.Errorf("attempt %d: %w\n", attempts, err1))
 			} else {

--- a/internal/transport/ssh/client.go
+++ b/internal/transport/ssh/client.go
@@ -122,7 +122,7 @@ func (c *client) init(ctx context.Context) error {
 		Auth:            []xssh.AuthMethod{},
 	}
 
-	c.clientConfig.Config.SetDefaults() // Use the default ciphers and key exchanges
+	c.clientConfig.SetDefaults() // Use the default ciphers and key exchanges
 
 	if c.transportCfg.password != "" {
 		c.clientConfig.Auth = append(c.clientConfig.Auth, xssh.Password(c.transportCfg.password))

--- a/tools/create-source/main.go
+++ b/tools/create-source/main.go
@@ -36,7 +36,7 @@ var snakeReg = regexp.MustCompile("(^[A-Za-z])|_([A-Za-z])")
 
 func snakeToCamel(str string) string {
 	return snakeReg.ReplaceAllStringFunc(str, func(s string) string {
-		return strings.ToUpper(strings.Replace(s, "_", "", -1))
+		return strings.ToUpper(strings.ReplaceAll(s, "_", ""))
 	})
 }
 


### PR DESCRIPTION
### How to read this pull request
Rather than only support a single search method, we now allow advanced use cases where you can provide an `items.find()` AQL query directly to the data-source.

As you can see in the tests, this will allow us to configure an advanced query with `$or` matchers, and any other item query we might want to author down the road.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
- [x] Version file/release label updated, if release needed
