### PR TITLE
VAULT-35548: Add support for `telemetry` stanzas in `enos_vault_start`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 version: "2"
 run:
   issues-exit-code: 1

--- a/docs/resources/vault_start.md
+++ b/docs/resources/vault_start.md
@@ -32,7 +32,11 @@ As such, you will need to provide _all_ values except for `seals` until we make 
 - `config.cluster_name` (String) The Vault [cluster_addr](https://developer.hashicorp.com/vault/docs/configuration#cluster_addr) value
 - `config.listener` (Object) The Vault [listener](https://developer.hashicorp.com/vault/docs/configuration/listener) stanza
 - `config.listener.type` (String) The Vault [listener](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp) stanza value. Currently 'tcp' is the only supported listener
-- `config.listener.attributes` (Object) The Vault [listener](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#tcp-listener-parameters) parameters for the tcp listener
+- `config.listener.attributes` (Object) The Vault [listener](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#tcp-listener-parameters) top-level parameters for the listener
+- `config.listener.telemetry` (Object) The Vault listener [telemetry](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#telemetry-parameters) stanza
+- `config.listener.profiling` (Object) The Vault listener [profiling](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#profiling-parameters) stanza
+- `config.listener.inflight_requests_logging` (Object) The Vault listener [inflight_requests_logging](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#inflight_requests_logging-parameters) stanza
+- `config.listener.custom_response_headers` (Object) The Vault listener [custom_response_headers](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#custom_response_headers-parameters) stanza
 - `config.log_level` (String) The Vault [log_level](https://developer.hashicorp.com/vault/docs/configuration#log_level)
 - `config.storage` (Object) The Vault [storage](https://developer.hashicorp.com/vault/docs/configuration/storage) stanza
 - `config.storage.type` (String) The Vault [storage](https://developer.hashicorp.com/vault/docs/configuration/storage) type
@@ -50,7 +54,8 @@ As such, you will need to provide _all_ values except for `seals` until we make 
 - `config.seals.secondary.attributes` (String) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) parameters for the given seal type
 - `config.seals.tertiary` (Object) The tertiary [HA seal](https://developer.hashicorp.com/vault/docs/configuration/seal/seal-ha) stanza. Tertiary has priority 3
 - `config.seals.tertiary.type` (String) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) type
-- `config.seals.tertiary.attributes` (String) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) parameters for the given seal type (see [below for nested schema](#nestedatt--config))
+- `config.seals.tertiary.attributes` (String) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) parameters for the given seal type
+- `config.telemetry` (Object) The Vault [telemetry](https://developer.hashicorp.com/vault/docs/configuration/telemetry#telemetry-parameters) stanza (see [below for nested schema](#nestedatt--config))
 
 ### Optional
 
@@ -88,21 +93,13 @@ Required:
 - `api_addr` (String)
 - `cluster_addr` (String)
 - `cluster_name` (String)
-- `listener` (Object) (see [below for nested schema](#nestedobjatt--config--listener))
+- `listener` (Dynamic)
 - `log_level` (String)
 - `seal` (Object) (see [below for nested schema](#nestedobjatt--config--seal))
 - `seals` (Dynamic)
 - `storage` (Dynamic)
+- `telemetry` (Dynamic)
 - `ui` (Boolean)
-
-<a id="nestedobjatt--config--listener"></a>
-### Nested Schema for `config.listener`
-
-Required:
-
-- `attributes` (Dynamic)
-- `type` (String)
-
 
 <a id="nestedobjatt--config--seal"></a>
 ### Nested Schema for `config.seal`

--- a/enos/modules/aws_ssh_vault_cluster/vault-instances.tf
+++ b/enos/modules/aws_ssh_vault_cluster/vault-instances.tf
@@ -112,6 +112,16 @@ resource "enos_vault_start" "leader" {
         address     = "0.0.0.0:8200"
         tls_disable = "true"
       }
+      // Turn on a bunch of unathenticated options that are optional on the leader
+      telemetry = {
+        unauthenticated_metrics_access = true
+      }
+      profiling = {
+        unauthenticated_pprof_access = true
+      }
+      inflight_requests_logging = {
+        unauthenticated_in_flight_request_access = true
+      }
     }
     log_level = var.vault_log_level
     storage = {
@@ -122,6 +132,10 @@ resource "enos_vault_start" "leader" {
     // NOTE: using our seals key here and seal for followers to ensure backwards compat
     seals = {
       "primary" = local.seal[var.unseal_method]
+    }
+    // Turn on some telemetry options on the leader
+    telemetry = {
+      enable_hostname_label = true,
     }
     ui = true
   }

--- a/internal/plugin/vault_config_listener.go
+++ b/internal/plugin/vault_config_listener.go
@@ -1,0 +1,223 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type vaultListenerConfig struct {
+	Type *tfString
+
+	// Top-level listener attributes
+	Attrs *dynamicPseudoTypeBlock
+
+	// telemetry stanza
+	Telemetry *dynamicPseudoTypeBlock
+
+	// Profiling stanza
+	Profiling *dynamicPseudoTypeBlock
+
+	// inflight_requests_logging stanza
+	IRL *dynamicPseudoTypeBlock
+
+	// customer_response_headers stanza
+	CRH *dynamicPseudoTypeBlock
+
+	// keep these around for marshaling the dynamic value
+	RawValues map[string]tftypes.Value
+	RawValue  tftypes.Value
+
+	Unknown bool
+	Null    bool
+}
+
+type vaultListenerConfigSet struct {
+	typ   string
+	attrs map[string]map[string]any
+}
+
+func newVaultListenerConfig() *vaultListenerConfig {
+	return &vaultListenerConfig{
+		Type:      newTfString(),
+		Attrs:     newDynamicPseudoTypeBlock(),
+		Telemetry: newDynamicPseudoTypeBlock(),
+		Profiling: newDynamicPseudoTypeBlock(),
+		IRL:       newDynamicPseudoTypeBlock(),
+		CRH:       newDynamicPseudoTypeBlock(),
+		Unknown:   false,
+		Null:      true,
+	}
+}
+
+func newVaultListenerConfigSet(typ string, attrs map[string]map[string]any) *vaultListenerConfigSet {
+	return &vaultListenerConfigSet{typ: typ, attrs: attrs}
+}
+
+func (s *vaultListenerConfig) Set(set *vaultListenerConfigSet) {
+	if s == nil || set == nil {
+		return
+	}
+
+	s.Unknown = false
+	s.Type.Set(set.typ)
+
+	for name, values := range set.attrs {
+		switch name {
+		case "attributes":
+			s.Attrs.Object.Set(values)
+		case "telemetry":
+			s.Telemetry.Object.Set(values)
+		case "profiling":
+			s.Profiling.Object.Set(values)
+		case "inflight_requests_logging":
+			s.IRL.Object.Set(values)
+		case "customer_response_headers":
+			s.CRH.Object.Set(values)
+		}
+	}
+}
+
+// FromTerraform5Value unmarshals the value to the struct.
+func (s *vaultListenerConfig) FromTerraform5Value(val tftypes.Value) error {
+	if s == nil {
+		return AttributePathError(fmt.Errorf("cannot unmarshal %s into nil vault listener config", val.String()),
+			"config", "listener",
+		)
+	}
+
+	if val.IsNull() {
+		s.Null = true
+		s.Unknown = false
+
+		return nil
+	}
+
+	if !val.IsKnown() {
+		s.Unknown = true
+
+		return nil
+	}
+
+	s.Null = false
+	s.Unknown = false
+	s.RawValue = val
+	s.RawValues = map[string]tftypes.Value{}
+	err := val.As(&s.RawValues)
+	if err != nil {
+		return err
+	}
+
+	// Decode each nested attribute
+	for k, v := range s.RawValues {
+		switch k {
+		case "type":
+			err = s.Type.FromTFValue(v)
+			if err != nil {
+				return err
+			}
+		case "attributes":
+			err = s.Attrs.FromTFValue(v)
+			if err != nil {
+				return err
+			}
+		case "telemetry":
+			err = s.Telemetry.FromTFValue(v)
+			if err != nil {
+				return err
+			}
+		case "profiling":
+			err = s.Profiling.FromTFValue(v)
+			if err != nil {
+				return err
+			}
+		case "inflight_requests_logging":
+			err = s.IRL.FromTFValue(v)
+			if err != nil {
+				return err
+			}
+		case "customer_response_headers":
+			err = s.CRH.FromTFValue(v)
+			if err != nil {
+				return err
+			}
+		default:
+			return AttributePathError(fmt.Errorf("unknown configuration '%s'", k), "config", "listener")
+		}
+	}
+
+	return nil
+}
+
+// Terraform5Type is the tftypes.Type.
+func (s *vaultListenerConfig) Terraform5Type() tftypes.Type {
+	return tftypes.DynamicPseudoType
+}
+
+// Terraform5Value is the tftypes.Value.
+func (s *vaultListenerConfig) Terraform5Value() tftypes.Value {
+	if s.Null {
+		return tftypes.NewValue(s.Terraform5Type(), nil)
+	}
+
+	if s.Unknown {
+		return tftypes.NewValue(s.Terraform5Type(), tftypes.UnknownValue)
+	}
+
+	attrs := map[string]tftypes.Type{}
+	vals := map[string]tftypes.Value{}
+	for name := range s.RawValues {
+		var val tftypes.Value
+		var err error
+		switch name {
+		case "type":
+			val = s.Type.TFValue()
+		case "attributes":
+			val, err = s.Attrs.TFValue()
+			if err != nil {
+				panic(err)
+			}
+		case "telemetry":
+			val, err = s.Telemetry.TFValue()
+			if err != nil {
+				panic(err)
+			}
+		case "profiling":
+			val, err = s.Profiling.TFValue()
+			if err != nil {
+				panic(err)
+			}
+		case "inflight_requests_logging":
+			val, err = s.IRL.TFValue()
+			if err != nil {
+				panic(err)
+			}
+		case "customer_response_headers":
+			val, err = s.CRH.TFValue()
+			if err != nil {
+				panic(err)
+			}
+		default:
+		}
+
+		attrs[name] = val.Type()
+		vals[name] = val
+	}
+
+	if len(vals) == 0 {
+		return tftypes.NewValue(tftypes.DynamicPseudoType, nil)
+	}
+
+	// Depending on how many are set, Terraform might pass the configuration over
+	// as a map or object, so we need to handle both.
+	if s.RawValue.Type().Is(tftypes.Map{}) {
+		for _, val := range vals {
+			return tftypes.NewValue(tftypes.Map{ElementType: val.Type()}, vals)
+		}
+	}
+
+	return tftypes.NewValue(tftypes.Object{AttributeTypes: attrs}, vals)
+}

--- a/internal/plugin/vault_config_listener.go
+++ b/internal/plugin/vault_config_listener.go
@@ -15,19 +15,15 @@ type vaultListenerConfig struct {
 	// Top-level listener attributes
 	Attrs *dynamicPseudoTypeBlock
 
-	// telemetry stanza
+	// Sub-stanzas in 'listener'
 	Telemetry *dynamicPseudoTypeBlock
-
-	// Profiling stanza
 	Profiling *dynamicPseudoTypeBlock
-
 	// inflight_requests_logging stanza
 	IRL *dynamicPseudoTypeBlock
-
-	// customer_response_headers stanza
+	// custom_response_headers stanza
 	CRH *dynamicPseudoTypeBlock
 
-	// keep these around for marshaling the dynamic value
+	// Keep the raw values around for marshaling the dynamic value
 	RawValues map[string]tftypes.Value
 	RawValue  tftypes.Value
 
@@ -75,7 +71,7 @@ func (s *vaultListenerConfig) Set(set *vaultListenerConfigSet) {
 			s.Profiling.Object.Set(values)
 		case "inflight_requests_logging":
 			s.IRL.Object.Set(values)
-		case "customer_response_headers":
+		case "custom_response_headers":
 			s.CRH.Object.Set(values)
 		}
 	}
@@ -139,7 +135,7 @@ func (s *vaultListenerConfig) FromTerraform5Value(val tftypes.Value) error {
 			if err != nil {
 				return err
 			}
-		case "customer_response_headers":
+		case "custom_response_headers":
 			err = s.CRH.FromTFValue(v)
 			if err != nil {
 				return err
@@ -195,7 +191,7 @@ func (s *vaultListenerConfig) Terraform5Value() tftypes.Value {
 			if err != nil {
 				panic(err)
 			}
-		case "customer_response_headers":
+		case "custom_response_headers":
 			val, err = s.CRH.TFValue()
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
Add support for configuring top-level `telemetry` configuration in the `enos_vault_start.config` attribute, as well as various missing stanzas in the `enos_vault_start.config.listener`.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
- [x] Version file/release label updated, if release needed
