### PR TITLE
VAULT-38894: update artifactory tests to use staging or prod artifacts

### DIFF
--- a/internal/artifactory/aql_test.go
+++ b/internal/artifactory/aql_test.go
@@ -28,7 +28,7 @@ func EnsureArtifactoryEnvAuth(t *testing.T) (map[string]string, bool) {
 	}
 
 	if !okacc || (okuser && !oktoken) || (!okuser && !okbearertoken) {
-		t.Logf(`skipping data "enos_artifactory_item" test because one or more of the following isn't set: 
+		t.Logf(`skipping data "enos_artifactory_item" test because one or more of the following isn't set:
 			TF_ACC(%t), ARTIFACTORY_TOKEN(%t), ARTIFACTORY_BEARER_TOKEN(%t)`,
 			okacc, oktoken, okbearertoken,
 		)
@@ -57,7 +57,7 @@ func EnsureArtifactoryEnvVars(t *testing.T) (map[string]string, bool) {
 	vars["revision"], okrev = os.LookupEnv("ARTIFACTORY_REVISION")
 
 	if !okacc || (okuser && !oktoken) || (!okuser && !okbearertoken) || !okver || !okrev {
-		t.Logf(`skipping data "enos_artifactory_item" test because one or more of the following isn't set: 
+		t.Logf(`skipping data "enos_artifactory_item" test because one or more of the following isn't set:
 			TF_ACC(%t), ARTIFACTORY_TOKEN(%t), ARTIFACTORY_BEARER_TOKEN(%t), ARTIFACTORY_PRODUCT_VERSION(%t), ARTIFACTORY_REVISION(%t)`,
 			okacc, oktoken, okbearertoken, okver, okrev,
 		)
@@ -90,7 +90,7 @@ func TestAccSearchAQL(t *testing.T) {
 		{
 			Name: "all search fields",
 			Args: []SearchAQLOpt{
-				WithRepo("hashicorp-crt-stable-local*"),
+				WithRepo("hashicorp-crt-staging-local*"),
 				WithPath("vault/*"),
 				WithName("*.zip"),
 				WithProperties(map[string]string{
@@ -115,7 +115,7 @@ func TestAccSearchAQL(t *testing.T) {
 		{
 			Name: "no path",
 			Args: []SearchAQLOpt{
-				WithRepo("hashicorp-crt-stable-local*"),
+				WithRepo("hashicorp-crt-staging-local*"),
 				WithName("*.zip"),
 				WithProperties(map[string]string{
 					"product-name":    "vault",
@@ -127,7 +127,7 @@ func TestAccSearchAQL(t *testing.T) {
 		{
 			Name: "no name",
 			Args: []SearchAQLOpt{
-				WithRepo("hashicorp-crt-stable-local*"),
+				WithRepo("hashicorp-crt-staging-local*"),
 				WithPath("vault/*"),
 				WithProperties(map[string]string{
 					"product-name":    "vault",
@@ -139,7 +139,7 @@ func TestAccSearchAQL(t *testing.T) {
 		{
 			Name: "no properties",
 			Args: []SearchAQLOpt{
-				WithRepo("hashicorp-crt-stable-local*"),
+				WithRepo("hashicorp-crt-staging-local*"),
 				WithPath("vault/*"),
 				WithName("*.zip"),
 			},
@@ -203,7 +203,7 @@ items.find(
       [
         {"@commit": { "$match": "{{ .SHA }}" }},
         {"@product-name": { "$match": "vault" }},
-        {"repo": { "$match": "hashicorp-crt-stable-local*" }},
+        {"repo": { "$match": "hashicorp-crt-staging-local*" }},
         {"path": { "$match": "vault/*" }},
         {"name": { "$match": "{{ .Name }}"}}
       ]
@@ -213,7 +213,7 @@ items.find(
       [
         {"@build.number": { "$match": "{{ .SHA }}" }},
         {"@build.name": { "$match": "vault" }},
-        {"repo": { "$match": "hashicorp-crt-stable-local*" }},
+        {"repo": { "$match": "hashicorp-crt-staging-local*" }},
         {"path": { "$match": "vault/*" }},
         {"name": { "$match": "{{ .Name }}"}}
       ]
@@ -237,7 +237,7 @@ items.find(
 		{
 			Name:         "old crt fields",
 			ArtifactName: "vault_1.19.0-1_amd64.deb",
-			SHA:          "ea8260c5893f2f38c3daa7aed07e89d85613844f",
+			SHA:          "7eeafb6160d60ede73c1d95566b0c8ea54f3cb5a",
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {

--- a/internal/plugin/datasource_artifactory_item_test.go
+++ b/internal/plugin/datasource_artifactory_item_test.go
@@ -22,14 +22,14 @@ import (
 //nolint:paralleltest// because our resource handles it
 func TestAccDataSourceArtifactoryItemProperties(t *testing.T) {
 	for name, props := range map[string]map[string]string{
-		"vault-1.18.5-1.x86_64.rpm": {
-			"commit":          "06a36557c4904c52f720bafb71866d389385f5ad",
-			"product-name":    "vault",
-			"product-version": "1.18.5",
-		},
 		"vault-1.19.1-1.x86_64.rpm": {
-			"build.number": "69bb3e9e943962d8fc2aa8a12031d35d2aac9a68",
+			"build.number": "aa75903ec499b2236da9e7bbbfeb7fd16fa4fd9d",
 			"build.name":   "vault-1.19.1",
+		},
+		"vault-1.19.2-1.x86_64.rpm": {
+			"commit":          "2ee4ea013b31a770a2fc421bb1e4bc74a9669185",
+			"product-name":    "vault",
+			"product-version": "1.19.2",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestAccDataSourceArtifactoryItemProperties(t *testing.T) {
 			}
 
 			if !okacc || !oktoken {
-				t.Logf(`skipping data "enos_artifactory_item" test because one or more of the following isn't set: 
+				t.Logf(`skipping data "enos_artifactory_item" test because one or more of the following isn't set:
 					TF_ACC(%t), ARTIFACTORY_TOKEN(%t), ARTIFACTORY_BEARER_TOKEN(%t)`,
 					okacc, oktoken, okbearertoken,
 				)
@@ -57,7 +57,7 @@ func TestAccDataSourceArtifactoryItemProperties(t *testing.T) {
 			state.Username.Set(username)
 			state.Token.Set(token)
 			state.Host.Set("https://artifactory.hashicorp.engineering/artifactory")
-			state.Repo.Set("hashicorp-crt-stable-local*")
+			state.Repo.Set("hashicorp-crt-staging-local*")
 			state.Path.Set("vault/*")
 			state.Name.Set(name)
 			state.Properties.SetStrings(props)
@@ -119,7 +119,7 @@ items.find(
       [
         {"@commit": { "$match": "{{ .SHA }}" }},
         {"@product-name": { "$match": "vault" }},
-        {"repo": { "$match": "hashicorp-crt-stable-local*" }},
+        {"repo": { "$match": "hashicorp-crt-staging-local*" }},
         {"path": { "$match": "vault/*" }},
         {"name": { "$match": "{{ .Name }}"}}
       ]
@@ -129,7 +129,7 @@ items.find(
       [
         {"@build.number": { "$match": "{{ .SHA }}" }},
         {"@build.name": { "$match": "vault" }},
-        {"repo": { "$match": "hashicorp-crt-stable-local*" }},
+        {"repo": { "$match": "hashicorp-crt-staging-local*" }},
         {"path": { "$match": "vault/*" }},
         {"name": { "$match": "{{ .Name }}"}}
       ]
@@ -141,7 +141,7 @@ items.find(
 		// New CRT fields
 		"vault_1.19.1-1_amd64.deb": "aa75903ec499b2236da9e7bbbfeb7fd16fa4fd9d",
 		// Old CRT fields
-		"vault_1.19.0-1_amd64.deb": "ea8260c5893f2f38c3daa7aed07e89d85613844f",
+		"vault_1.19.0-1_amd64.deb": "7eeafb6160d60ede73c1d95566b0c8ea54f3cb5a",
 	} {
 		t.Run(name, func(t *testing.T) {
 			state := newArtifactoryItemStateV1()
@@ -156,7 +156,7 @@ items.find(
 			}
 
 			if !okacc || (okuser && !oktoken) || (!okuser && !okbearertoken) {
-				t.Logf(`skipping data "enos_artifactory_item" test because one or more of the following isn't set: 
+				t.Logf(`skipping data "enos_artifactory_item" test because one or more of the following isn't set:
 					TF_ACC(%t), ARTIFACTORY_TOKEN(%t), ARTIFACTORY_BEARER_TOKEN(%t)`,
 					okacc, oktoken, okbearertoken,
 				)

--- a/internal/plugin/resource_bundle_install_test.go
+++ b/internal/plugin/resource_bundle_install_test.go
@@ -183,8 +183,8 @@ func TestAccResourceBundleInstall(t *testing.T) {
 				bundleInstallArtifactoryInstall.Artifactory.Username.Set(artUser)
 			}
 			bundleInstallArtifactoryInstall.Artifactory.Token.Set(artToken)
-			bundleInstallArtifactoryInstall.Artifactory.URL.Set("https://artifactory.hashicorp.engineering/artifactory/hashicorp-packagespec-buildcache-local/cache-v1/vault-enterprise/7fb88d4d3d0a36ffc78a522d870492e5791bae1b0640232ce4c6d69cc22cf520/store/f45845666b4e552bfc8ca775834a3ef6fc097fe0-1a2809da73e5896b6f766b395ff6e1804f876c45.zip")
-			bundleInstallArtifactoryInstall.Artifactory.SHA256.Set("d01a82111133908167a5a140604ab3ec8fd18601758376a5f8e9dd54c7703373")
+			bundleInstallArtifactoryInstall.Artifactory.URL.Set("https://artifactory.hashicorp.engineering/artifactory/hashicorp-crt-prod-local/vault-enterprise/1.20.2%2Bent/8e95c64a526fa9f8aa0b822fcf5080eb0f6226be/vault_1.20.2%2Bent_linux_amd64.zip")
+			bundleInstallArtifactoryInstall.Artifactory.SHA256.Set("081e592c87d9209e0e77b8e7092ba71d9be64ba6eee0fafc935d9044d9c2afb3")
 			ssh := newEmbeddedTransportSSH()
 			ssh.Host.Set(enosVars["host"])
 			require.NoError(t, bundleInstallArtifactoryInstall.Transport.SetTransportState(ssh))


### PR DESCRIPTION
### How to read this pull request
Re IPS-102: The retention policy for the stable channel is going to be reduced from indefinite to 90 days soon. Update our tests to use staging or prod repositories and artifacts therein.

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
- [x] Version file/release label updated, if release needed
