### PR TITLE
chore(scale): Add support to start boundary in pprof

### DIFF
--- a/docs/resources/boundary_start.md
+++ b/docs/resources/boundary_start.md
@@ -24,6 +24,7 @@ description: |-
 
 - `bin_name` (String) The name of boundary binary we're going to use when starting the cluster
 - `config_name` (String) The name of a Boundary configuration to use when starting the cluster
+- `debug` (Boolean) When true, start Boundary with the `-debug` flag
 - `license` (String, Sensitive) The path to a license for Boundary Enterprise
 - `manage_service` (Boolean) Whether or not Enos should supply a systemd unit for the service
 - `recording_storage_path` (String) The path to use for storage when recording

--- a/internal/plugin/resource_boundary_start.go
+++ b/internal/plugin/resource_boundary_start.go
@@ -43,6 +43,7 @@ type boundaryStartStateV1 struct {
 	SystemdUnitName      *tfString
 	Username             *tfString
 	RecordingStoragePath *tfString
+	Debug                *tfBool
 	Transport            *embeddedTransportV1
 	failureHandlers
 }
@@ -75,6 +76,7 @@ func newBoundaryStartStateV1() *boundaryStartStateV1 {
 		SystemdUnitName:      newTfString(),
 		Username:             newTfString(),
 		RecordingStoragePath: newTfString(),
+		Debug:                newTfBool(),
 		Transport:            transport,
 		failureHandlers:      fh,
 	}
@@ -278,6 +280,12 @@ func (s *boundaryStartStateV1) Schema() *tfprotov6.Schema {
 					Optional:    true,
 					Description: "The path to use for storage when recording",
 				},
+				{
+					Name:        "debug",
+					Type:        tftypes.Bool,
+					Optional:    true,
+					Description: "When true, start Boundary with the `-debug` flag",
+				},
 				s.Transport.SchemaAttributeTransport(supportsSSH),
 			},
 		},
@@ -318,6 +326,7 @@ func (s *boundaryStartStateV1) FromTerraform5Value(val tftypes.Value) error {
 		"unit_name":              s.SystemdUnitName,
 		"username":               s.Username,
 		"recording_storage_path": s.RecordingStoragePath,
+		"debug":                  s.Debug,
 	})
 	if err != nil {
 		return err
@@ -344,8 +353,8 @@ func (s *boundaryStartStateV1) Terraform5Type() tftypes.Type {
 		"unit_name":              s.SystemdUnitName.TFType(),
 		"username":               s.Username.TFType(),
 		"recording_storage_path": s.RecordingStoragePath.TFType(),
-
-		"transport": s.Transport.Terraform5Type(),
+		"debug":                  s.Debug.TFType(),
+		"transport":              s.Transport.Terraform5Type(),
 	}}
 }
 
@@ -363,6 +372,7 @@ func (s *boundaryStartStateV1) Terraform5Value() tftypes.Value {
 		"unit_name":              s.SystemdUnitName.TFValue(),
 		"username":               s.Username.TFValue(),
 		"recording_storage_path": s.RecordingStoragePath.TFValue(),
+		"debug":                  s.Debug.TFValue(),
 		"transport":              s.Transport.Terraform5Value(),
 	})
 }
@@ -460,6 +470,11 @@ func (s *boundaryStartStateV1) startBoundary(ctx context.Context, transport it.T
 			unitName = unit
 		}
 
+		execStart := fmt.Sprintf("%s/%s server -config %s", s.BinPath.Value(), binName, configFilePath)
+		if debug, ok := s.Debug.Get(); ok && debug {
+			execStart += " -debug"
+		}
+
 		unit := systemd.Unit{
 			"Unit": {
 				"Description":           "HashiCorp Boundary",
@@ -483,7 +498,7 @@ func (s *boundaryStartStateV1) startBoundary(ctx context.Context, transport it.T
 				"Capabilities":          "CAP_IPC_LOCK+ep",
 				"CapabilityBoundingSet": "CAP_SYSLOG CAP_IPC_LOCK",
 				"NoNewPrivileges":       "yes",
-				"ExecStart":             fmt.Sprintf("%s/%s server -config %s", s.BinPath.Value(), binName, configFilePath),
+				"ExecStart":             execStart,
 				"ExecReload":            "/bin/kill --signal HUP $MAINPID",
 				"KillMode":              "process",
 				"KillSignal":            "SIGINT",


### PR DESCRIPTION
Boundary had a recent change that enabled pproff debug mode through a cli flag rather than a build flag
https://github.com/hashicorp/boundary/pull/6644

This change adds a boolean in the boundary start module to start boundary with the -debug flag if true. 
Tested locally with e2e_aws_base enos scenario in the boundary repo. 

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [ ] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
- [ ] Version file/release label updated, if release needed
