### PR TITLE
storage: add support for multiple `retry_join` blocks in integrated storage config

### DIFF
--- a/docs/resources/vault_start.md
+++ b/docs/resources/vault_start.md
@@ -41,7 +41,7 @@ As such, you will need to provide _all_ values except for `seals` until we make 
 - `config.storage` (Object) The Vault [storage](https://developer.hashicorp.com/vault/docs/configuration/storage) stanza
 - `config.storage.type` (String) The Vault [storage](https://developer.hashicorp.com/vault/docs/configuration/storage) type
 - `config.storage.attributes` (Object) The Vault [storage](https://developer.hashicorp.com/vault/docs/configuration/storage) parameters for the given storage type
-- `config.storage.retry_join` (Object) The Vault integrated storage [retry_join](https://developer.hashicorp.com/vault/docs/configuration/storage/raft#retry_join-stanza) stanza
+- `config.storage.retry_join` (Object or List of Objects) The Vault integrated storage [retry_join](https://developer.hashicorp.com/vault/docs/configuration/storage/raft#retry_join-stanza) stanza. Can be a single object for one retry_join block, or a list of objects for multiple retry_join blocks for redundancy.
 - `config.seal` (Object) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) stanza
 - `config.seal.type` (String) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) type
 - `config.seal.attributes` (String) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) parameters for the given seal type

--- a/internal/plugin/resource_vault_start.go
+++ b/internal/plugin/resource_vault_start.go
@@ -310,7 +310,7 @@ As such, you will need to provide _all_ values except for ^seals^ until we make 
 - ^config.storage^ (Object) The Vault [storage](https://developer.hashicorp.com/vault/docs/configuration/storage) stanza
 - ^config.storage.type^ (String) The Vault [storage](https://developer.hashicorp.com/vault/docs/configuration/storage) type
 - ^config.storage.attributes^ (Object) The Vault [storage](https://developer.hashicorp.com/vault/docs/configuration/storage) parameters for the given storage type
-- ^config.storage.retry_join^ (Object) The Vault integrated storage [retry_join](https://developer.hashicorp.com/vault/docs/configuration/storage/raft#retry_join-stanza) stanza
+- ^config.storage.retry_join^ (Object or List of Objects) The Vault integrated storage [retry_join](https://developer.hashicorp.com/vault/docs/configuration/storage/raft#retry_join-stanza) stanza. Can be a single object for one retry_join block, or a list of objects for multiple retry_join blocks for redundancy.
 - ^config.seal^ (Object) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) stanza
 - ^config.seal.type^ (String) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) type
 - ^config.seal.attributes^ (String) The Vault [seal](https://developer.hashicorp.com/vault/docs/configuration/seal) parameters for the given seal type
@@ -734,29 +734,46 @@ func (c *vaultConfig) Render(configMode string) (*hcl.Builder, map[string]string
 				storageBlock.AppendAttributes(attrs)
 
 				if storageLabel == raftStorageType {
-					// Handle integrated storage defaults. We do this for backwards compatibility with older
-					// provider versions. Make sure to only set defaults if the user has not passed in the
-					// keys.
+					// Our integrated storage support is complicated because we support
+					// lots of implicit legacy behavior:
+					// - If no path is set we need to set it to a default path.
+					// - If no retry_join has been set then we set up an AWS auto_join
+					// - retry_join can be set to a singular object with attributes
+					// - retry_join can be set to a list of objects with attributes
+
 					if _, ok := attrs["path"]; !ok {
 						storageBlock.AppendAttribute("path", defaultRaftDataDir)
 					}
 
-					retryJoinBlock := storageBlock.AppendBlock("retry_join", []string{})
-					retryJoinAttrs, ok := c.Storage.RetryJoin.Object.GetObject()
-					if ok {
-						// We've been configured with retry_join so we'll set the attrs
-						retryJoinBlock.AppendAttributes(retryJoinAttrs)
-					} else {
-						// The user has not configured retry_join set so we'll use the old defaults for
-						// backwards compat.
-						clusterName, ok := c.ClusterName.Get()
-						if !ok {
-							// This shouldn't ever happen...
-							return nil, nil, errors.New("enos_vault_start.cluster_name must be set")
+					// If we've got multiple retry_joins write them out!
+					if retryJoins, ok := c.Storage.RetryJoins.Get(); ok && len(retryJoins) > 0 {
+						// Render multiple retry_join blocks
+						for _, retryJoin := range retryJoins {
+							if attrs, ok := retryJoin.GetObject(); ok {
+								storageBlock.AppendBlock("retry_join", []string{}).AppendAttributes(attrs)
+							}
 						}
+					} else {
+						// Single retry_join block. Write it out if we've been configured
+						// with one, otherwise add the aws discovery backwards compat
+						// auto_join.
+						retryJoinBlock := storageBlock.AppendBlock("retry_join", []string{})
+						retryJoinAttrs, ok := c.Storage.RetryJoin.Object.GetObject()
+						if ok {
+							// We've been configured with retry_join so we'll set the attrs
+							retryJoinBlock.AppendAttributes(retryJoinAttrs)
+						} else {
+							// The user has not configured retry_join set so we'll use the old
+							// defaults for backwards compat.
+							clusterName, ok := c.ClusterName.Get()
+							if !ok {
+								// This shouldn't ever happen...
+								return nil, nil, errors.New("enos_vault_start.cluster_name must be set")
+							}
 
-						retryJoinBlock.AppendAttribute("auto_join", "provider=aws tag_key=Type tag_value="+clusterName).
-							AppendAttribute("auto_join_scheme", "http")
+							retryJoinBlock.AppendAttribute("auto_join", "provider=aws tag_key=Type tag_value="+clusterName).
+								AppendAttribute("auto_join_scheme", "http")
+						}
 					}
 				}
 			}

--- a/internal/plugin/resource_vault_start_test.go
+++ b/internal/plugin/resource_vault_start_test.go
@@ -167,6 +167,21 @@ func TestAccResourceVaultStart(t *testing.T) {
           {{$name}} = "{{$val}}"
           {{end}}
         }
+        {{if .Config.Storage.RetryJoin.Object.Value -}}
+        retry_join = { {{range $name, $val := .Config.Storage.RetryJoin.Object.Value -}}
+          {{$name}} = "{{$val}}"
+          {{end}}
+        }
+        {{else if .Config.Storage.RetryJoins.Val -}}
+        retry_join = [
+          {{range $idx, $rj := .Config.Storage.RetryJoins.Val -}}
+          { {{range $name, $val := $rj.Value -}}
+            {{$name}} = "{{$val}}"
+            {{end}}
+          },
+          {{end -}}
+        ]
+        {{end -}}
       }
 
       {{if .Config.Telemetry.Object.Value -}}
@@ -276,6 +291,59 @@ func TestAccResourceVaultStart(t *testing.T) {
 			resource.TestCheckResourceAttr("enos_vault_start.foo", "config.username", "vaulter"),
 			resource.TestCheckResourceAttr("enos_vault_start.foo", "transport.ssh.user", "ubuntu"),
 			resource.TestCheckResourceAttr("enos_vault_start.foo", "transport.ssh.host", "localhost"),
+		),
+		false,
+	})
+
+	// Test case for multiple retry_join blocks
+	vaultStartMultiRetry := newVaultStartStateV1()
+	vaultStartMultiRetry.ID.Set("multi_retry")
+	vaultStartMultiRetry.BinPath.Set("/opt/vault/bin/vault")
+	vaultStartMultiRetry.ConfigDir.Set("/etc/vault.d")
+	vaultStartMultiRetry.Config.APIAddr.Set("http://127.0.0.1:8200")
+	vaultStartMultiRetry.Config.ClusterAddr.Set("http://127.0.0.1:8201")
+	vaultStartMultiRetry.Config.ClusterName.Set("multiretry")
+	vaultStartMultiRetry.Config.Listener.Set(newVaultListenerConfigSet(
+		"tcp", map[string]map[string]any{
+			"attributes": {
+				"address":     "0.0.0.0:8200",
+				"tls_disable": "true",
+			},
+		},
+	))
+	vaultStartMultiRetry.Config.LogLevel.Set("info")
+	vaultStartMultiRetry.Config.Storage.Type.Set("raft")
+	vaultStartMultiRetry.Config.Storage.Attrs.Object.Set(map[string]any{"path": "/opt/raft"})
+	// Set multiple retry_join blocks using the new RetryJoins field
+	vaultStartMultiRetry.Config.Storage.RetryJoins.SetObjects([]map[string]any{
+		{
+			"auto_join":        "provider=aws tag_key=Type tag_value=vault",
+			"auto_join_scheme": "https",
+		},
+		{
+			"leader_api_addr": "http://vault-1:8200",
+		},
+		{
+			"leader_api_addr": "http://vault-2:8200",
+		},
+	})
+	sshMulti := newEmbeddedTransportSSH()
+	sshMulti.User.Set("ubuntu")
+	sshMulti.Host.Set("localhost")
+	privateKeyMulti, err := readTestFile("../fixtures/ssh.pem")
+	require.NoError(t, err)
+	sshMulti.PrivateKey.Set(privateKeyMulti)
+	require.NoError(t, vaultStartMultiRetry.Transport.SetTransportState(sshMulti))
+	cases = append(cases, testAccResourceTemplate{
+		"multiple retry_join blocks",
+		vaultStartMultiRetry,
+		resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("enos_vault_start.multi_retry", "id", "static"),
+			resource.TestCheckResourceAttr("enos_vault_start.multi_retry", "config.storage.type", "raft"),
+			resource.TestCheckResourceAttr("enos_vault_start.multi_retry", "config.storage.retry_join.0.auto_join", "provider=aws tag_key=Type tag_value=vault"),
+			resource.TestCheckResourceAttr("enos_vault_start.multi_retry", "config.storage.retry_join.0.auto_join_scheme", "https"),
+			resource.TestCheckResourceAttr("enos_vault_start.multi_retry", "config.storage.retry_join.1.leader_api_addr", "http://vault-1:8200"),
+			resource.TestCheckResourceAttr("enos_vault_start.multi_retry", "config.storage.retry_join.2.leader_api_addr", "http://vault-2:8200"),
 		),
 		false,
 	})

--- a/internal/plugin/vault_config_seals.go
+++ b/internal/plugin/vault_config_seals.go
@@ -141,6 +141,10 @@ func (s *vaultSealsConfig) Terraform5Type() tftypes.Type {
 // Terraform5Value is the tftypes.Value.
 func (s *vaultSealsConfig) Terraform5Value() tftypes.Value {
 	if s.Null {
+		if s.RawValue.Type() != nil {
+			return tftypes.NewValue(s.RawValue.Type(), map[string]tftypes.Value{})
+		}
+
 		return tftypes.NewValue(tftypes.DynamicPseudoType, nil)
 	}
 
@@ -166,6 +170,10 @@ func (s *vaultSealsConfig) Terraform5Value() tftypes.Value {
 	}
 
 	if len(vals) == 0 {
+		if s.RawValue.Type() != nil {
+			return tftypes.NewValue(s.RawValue.Type(), map[string]tftypes.Value{})
+		}
+
 		return tftypes.NewValue(tftypes.DynamicPseudoType, nil)
 	}
 

--- a/internal/plugin/vault_config_storage.go
+++ b/internal/plugin/vault_config_storage.go
@@ -12,8 +12,12 @@ import (
 type vaultStorageConfig struct {
 	Type *tfString
 
-	Attrs     *dynamicPseudoTypeBlock
-	RetryJoin *dynamicPseudoTypeBlock
+	Attrs *dynamicPseudoTypeBlock
+
+	// We use a different backing type depending on whether or not retry_join
+	// has been configured with a single or multiple retry_join blocks.
+	RetryJoin  *dynamicPseudoTypeBlock
+	RetryJoins *tfObjectSlice
 
 	// keep these around for marshaling the dynamic value
 	RawValues map[string]tftypes.Value
@@ -31,11 +35,12 @@ type vaultStorageConfigSet struct {
 
 func newVaultStorageConfig() *vaultStorageConfig {
 	return &vaultStorageConfig{
-		Type:      newTfString(),
-		Attrs:     newDynamicPseudoTypeBlock(),
-		RetryJoin: newDynamicPseudoTypeBlock(),
-		Unknown:   false,
-		Null:      true,
+		Type:       newTfString(),
+		Attrs:      newDynamicPseudoTypeBlock(),
+		RetryJoin:  newDynamicPseudoTypeBlock(),
+		RetryJoins: newTfObjectSlice(),
+		Unknown:    false,
+		Null:       true,
 	}
 }
 
@@ -104,7 +109,16 @@ func (s *vaultStorageConfig) FromTerraform5Value(val tftypes.Value) error {
 				return err
 			}
 		case "retry_join":
-			err = s.RetryJoin.FromTFValue(v)
+			// Terraform can send lists as either tftypes.List or tftypes.Tuple
+			// depending on the number of elements.
+			_, isList := v.Type().(tftypes.List)
+			_, isTuple := v.Type().(tftypes.Tuple)
+			if isList || isTuple {
+				err = s.RetryJoins.FromTFValue(v)
+			} else {
+				// Assume it's a singular retry_join block
+				err = s.RetryJoin.FromTFValue(v)
+			}
 			if err != nil {
 				return err
 			}
@@ -148,6 +162,17 @@ func (s *vaultStorageConfig) Terraform5Value() tftypes.Value {
 				panic(err)
 			}
 		case "retry_join":
+			// If we're given multiple blocks, preserve the original retry_join during
+			// plan so we can appropriately marshal it.
+			if rawVal, ok := s.RawValues[name]; ok {
+				_, isList := rawVal.Type().(tftypes.List)
+				_, isTuple := rawVal.Type().(tftypes.Tuple)
+				if (isList || isTuple) && s.RetryJoins != nil && len(s.RetryJoins.Val) > 0 {
+					val = rawVal
+					break
+				}
+			}
+
 			val, err = s.RetryJoin.TFValue()
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
Add support for configuring multiple `retry_join` blocks in `enos_vault_start.config.storage`. This allows us to configure, for example, `leader_api_addr` config for all nodes in a cluster when not using an auto-discovery mechanism. This is necessary as we like to intentionally cause leader elections in tests and without all nodes knowing about each other we can end up with orphaned nodes.

We still support no `retry_join`, or a singular `retry_join`, being set for backwards compat.

Examples
```hcl
resource "enos_vault_start" "old_singular" {
  config = {
    storage = {
      type = "raft"
      retry_join = {
        auto_join = "provider=aws tag_key=Type tag_value=vault"
        auto_join_scheme = "https"
      }
    }
  }
}

resource "enos_vault_start" "new_multiple" {
  config = {
    storage = {
      type = "raft"
      retry_join = [
        {
          auto_join = "provider=aws tag_key=VaultCluster tag_value=Cluster1"
          auto_join_scheme = "https"
        },
        {
          leader_api_addr = "http://vault-1:8200"
        },
        {
          leader_api_addr = "http://vault-2:8200"
        }
      ]
    }
  }
}
```

### Checklist
- [x] The commit message includes an explanation of the changes
- [x] Manual validation of the changes have been performed (if possible)
- [x] New or modified code has requisite test coverage (if possible)
- [x] I have performed a self-review of the changes
- [x] I have made necessary changes and/or pull requests for documentation
- [x] I have written useful comments in the code
- [x] Version file/release label updated, if release needed
